### PR TITLE
Automatically determine file format of URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.DS_Store
-
+.Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rio
 Type: Package
 Title: A Swiss-army knife for data I/O
 Version: 0.1.3
-Date: 2015-02-24
+Date: 2015-02-25
 Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
 Authors@R: c(person("Chung-hong", "Chan", role = c("aut", "cre"), email = "chainsawtiney@gmail.com"),
 	         person("Geoffrey CH", "Chan", role = "aut", email = "gefchchan@gmail.com"),

--- a/R/import.R
+++ b/R/import.R
@@ -24,12 +24,19 @@ import.rdata <- function(file, ...) {
 }
 
 import <- function(file, format, ...) {
-    if(missing(format))
-        fmt <- get_ext(file)
+    if(missing(file)) stop("file is required.", .call = F)
+    if(missing(format)) {
+        if (!grepl("^http.*://", file)) {
+            fmt <- get_ext(file)
+        }
+        else if (grepl("^http.*://", file)) {
+            fmt <- gsub("(.*\\/)([^.]+)\\.", "", file)
+        }
+    }
     else
         fmt <- tolower(format)
     if(grepl("^https://", file)) {
-        temp_file <- tempfile(fileext = format)
+        temp_file <- tempfile(fileext = fmt)
         on.exit(unlink(temp_file))
         curl_download(file, temp_file, mode = "wb")
         file <- temp_file

--- a/R/import.R
+++ b/R/import.R
@@ -24,7 +24,6 @@ import.rdata <- function(file, ...) {
 }
 
 import <- function(file, format, ...) {
-    if(missing(file)) stop("file is required.", .call = F)
     if(missing(format)) {
         if (!grepl("^http.*://", file)) {
             fmt <- get_ext(file)

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,9 +14,6 @@ get_type <- function(fmt) {
 }
 
 get_ext <- function(file) {
-    if (!is.character(file)) {
-        stop("'file' is not a string")
-    }
     fmt <- file_ext(file)
     if(file == "clipboard") {
         return("clipboard")

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,6 +14,9 @@ get_type <- function(fmt) {
 }
 
 get_ext <- function(file) {
+    if (!is.character(file)) {
+        stop("'file' is not a string")
+    }
     fmt <- file_ext(file)
     if(file == "clipboard") {
         return("clipboard")

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,9 +6,9 @@ The aim of **rio** is to make data file I/O in R as easy as possible by implemen
  - `convert` wraps `import` and `export` to allow the user to easily convert between file formats (thus providing a FOSS replacement for programs like [Stat/Transfer](https://www.stattransfer.com/) or [Sledgehammer](http://www.openmetadata.org/site/?page_id=1089))
 
 The core advantage of **rio** is that it makes assumptions that the user is probably willing to make. Two of these are important. First, **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By taking away the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Second, when importing tabular data (CSV, TSV, etc.), **rio** does not convert strings to factors.
- 
+
 Another weakness of the base R data I/O functions is that they only support import of web-based data from websites serving HTTP, not HTTPS. For example, data stored on GitHub as publicly visible files cannot be read directly into R without either manually downloading them or reading them in via **RCurl** or **httr**. **rio** removes those steps by supporting HTTPS imports automatically.
- 
+
 The package also wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. Namely, the package uses [**haven**](https://github.com/hadley/haven) for reading and writing SAS, Stata, and SPSS files and [**fastread**](https://github.com/hadley/fastread) for reading simple text-delimited and fixed-width file formats.
 
 ## Supported file formats ##
@@ -67,6 +67,7 @@ if(!require("devtools")){
     install.packages("devtools")
     library("devtools")
 }
+install_github("hadley/haven")
 install_github("leeper/rio")
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The aim of **rio** is to make data file I/O in R as easy as possible by implemen
  - `convert` wraps `import` and `export` to allow the user to easily convert between file formats (thus providing a FOSS replacement for programs like [Stat/Transfer](https://www.stattransfer.com/) or [Sledgehammer](http://www.openmetadata.org/site/?page_id=1089))
 
 The core advantage of **rio** is that it makes assumptions that the user is probably willing to make. Two of these are important. First, **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By taking away the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Second, when importing tabular data (CSV, TSV, etc.), **rio** does not convert strings to factors.
- 
+
 Another weakness of the base R data I/O functions is that they only support import of web-based data from websites serving HTTP, not HTTPS. For example, data stored on GitHub as publicly visible files cannot be read directly into R without either manually downloading them or reading them in via **RCurl** or **httr**. **rio** removes those steps by supporting HTTPS imports automatically.
- 
+
 The package also wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. Namely, the package uses [**haven**](https://github.com/hadley/haven) for reading and writing SAS, Stata, and SPSS files and [**fastread**](https://github.com/hadley/fastread) for reading simple text-delimited and fixed-width file formats.
 
 ## Supported file formats ##
@@ -67,6 +67,7 @@ if(!require("devtools")){
     install.packages("devtools")
     library("devtools")
 }
+install_github("hadley/haven")
 install_github("leeper/rio")
 ```
 


### PR DESCRIPTION
This pull request:

- Allows `import` to automatically determine the file format of a URL (for example a CSV file stored at a Raw GitHub URL).

Here is an example: 

```{S}
URL = 'https://raw.githubusercontent.com/christophergandrud/yrcurnt_corrected/master/data/yrcurnt_original_corrected.csv'

rio::import(URL)
```

- Adds to the README a `github_install` call to install *haven*, which is not currently on CRAN.