### PR TITLE
moved https format find to `get_ext`

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -24,14 +24,8 @@ import.rdata <- function(file, ...) {
 }
 
 import <- function(file, format, ...) {
-    if(missing(format)) {
-        if (!grepl("^http.*://", file)) {
-            fmt <- get_ext(file)
-        }
-        else if (grepl("^http.*://", file)) {
-            fmt <- gsub("(.*\\/)([^.]+)\\.", "", file)
-        }
-    }
+    if(missing(format))
+        fmt <- get_ext(file)
     else
         fmt <- tolower(format)
     if(grepl("^https://", file)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,12 @@ get_ext <- function(file) {
     if (!is.character(file)) {
         stop("'file' is not a string")
     }
-    fmt <- file_ext(file)
+    if(!grepl("^http.*://", file)) {
+        fmt <- file_ext(file)
+    }
+    else if(grepl("^http.*://", file)) {
+        fmt <- gsub("(.*\\/)([^.]+)\\.", "", file)
+    }
     if(file == "clipboard") {
         return("clipboard")
     } else if (fmt == "") {


### PR DESCRIPTION
Sorry, but it occurred to me that the code for finding a URL's file format should go in `get_ext` rather than be at `import`.