### PR TITLE
Removed install_github("hadley/haven")

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -53,7 +53,6 @@ if(!require("devtools")){
     install.packages("devtools")
     library("devtools")
 }
-install_github("hadley/haven")
 install_github("leeper/rio")
 ```
 


### PR DESCRIPTION
**haven** is now on [CRAN](http://cran.r-project.org/web/packages/haven/index.html), so it is no longer necessary to install the GitHub version.