### PR TITLE
Fixread ods

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -58,7 +58,8 @@ import.ods <- function(file, header = TRUE, sheet = NULL, ...) {
         return(g)
     }
     if (getNrOfSheetsInODS(file) > 1 & is.null(sheet)) {
-        warning("ODS file imported is multi-sheet, a list of data.frame will be returned")
+        warning(paste0("There are ", getNrOfSheetsInODS(file), " sheets in the ODS file. Only the first sheet will be returned. Use sheet option from read.ods to select which sheet to import."))
+        sheet <- 1
     } else if (getNrOfSheetsInODS(file) == 1) {
         sheet <- 1
     }

--- a/R/import.R
+++ b/R/import.R
@@ -50,7 +50,7 @@ import.rdata <- function(file, which = 1, ...) {
     get(ls(e)[which], e)
 }
 
-import.ods <- function(file, header = TRUE, sheet = 1, ...) {
+import.ods <- function(file, header = TRUE, sheet = NULL, ...) {
     handlingODSheader <- function(x) {
         colnames(x) <- x[1,]
         g <- x[2:nrow(x),]


### PR DESCRIPTION
Always return a data.frame (not a list of data.frame, which breaks the behavior of rio) and warn the user to select which sheet to import when the ods file imported is multisheet.
