### PR TITLE
cleanup haven results

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -51,11 +51,12 @@ import.fortran <- function(file = file, style, ...) {
     read.fortran(file = file, format = style, ...)
 }
 
-import.dta <- function(file = file, haven = TRUE, ...) {
+import.dta <- function(file = file, haven = TRUE, col.labs = FALSE ...) {
     if(haven) {
         a <- list(...)
         if(length(a))
-            warning("File imported using haven. Arguments to '...' ignored.")
+          warning("File imported using haven. Arguments to '...' ignored.")
+        if(col.labs) return(read_dta(path = file))
         x <- read_dta(path = file)
         xinfo <- list(var.labels = sapply(x, attr, which = "label"),
                       label.table = sapply(x, attr, which = "labels"))

--- a/R/import.R
+++ b/R/import.R
@@ -56,7 +56,15 @@ import.dta <- function(file = file, haven = TRUE, ...) {
         a <- list(...)
         if(length(a))
             warning("File imported using haven. Arguments to '...' ignored.")
-        read_dta(path = file)
+        x <- read_dta(path = file)
+        xinfo <- list(var.labels = sapply(x, attr, which = "label"),
+                      label.table = sapply(x, attr, which = "labels"))
+        discrete <- sapply(x, function(y) length(unique(attr(y, "labels"))) >= length(na.omit(unique(y))))
+        x[discrete] <- lapply(x[discrete], haven::as_factor)
+        x[sapply(x, is.numeric)] <- lapply(x[sapply(x, is.numeric)], function(y) {attr(y, "labels") <- NULL; return(y)})
+        x[] <- lapply(x, function(y) {attr(y, "label") <- NULL; return(y)})
+        for(a in names(xinfo)) {attr(x, a) <- xinfo[[a]]}
+        return(x)
     } else {
         read.dta(file = file, ...)
     }

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -24,7 +24,7 @@
     \item Serialized R objects (.rds), using \code{\link[base]{readRDS}}
     \item Saved R objects (.RData), using \code{\link[base]{load}} for single-object .Rdata files
     \item JSON (.json), using \code{\link[jsonlite]{fromJSON}}
-    \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
+    \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used. If haven is used \code{col.labs = FALSE} (this is the default) can be used to save metadata as data.frame attributes rather than column attributes.
     \item SPSS and SPSS portable (.sav and .por), using \code{\link[haven]{read_sav}} and \code{\link[haven]{read_por}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used for .sav files.
     \item "XBASE" database files (.dbf), using \code{\link[foreign]{read.dbf}}
     \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{read.arff}}


### PR DESCRIPTION
This is a first pass at fixing https://github.com/leeper/rio/issues/37 when importing stata data sets with haven. I stripped the attributes off of the individual columns and attached them to the data.frame. I used attribute names that are consistent with those returned by `foreign::read.dta`, so an added benefit is more consistent results regardless of whether `haven=TRUE` or `haven=FALSE`.

I've tested this on a few data sets and it appears to works well.