### PR TITLE
Adds preliminary support for sql sources using dplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person("Chung-hong", "Chan", role = "aut", email = "chainsawtiney@g
              person("Ista", "Zahn", role = "aut"))
 Description: Streamlined data import and export by making assumptions that the user is probably willing to make: 'import()' and 'export()' determine the data structure from the file extension, reasonable defaults are used for data import and export (e.g., 'stringsAsFactors=FALSE'), web-based import is natively supported (including from SSL/HTTPS), compressed files can be read directly without explicit decompression, and fast import packages are used where appropriate.
 Depends: R (>= 2.15.0)
-Imports: tools, utils, foreign, haven, longurl, openxlsx, readODS, jsonlite, XML, curl (>= 0.6), data.table (>= 1.9.5), readxl, yaml
+Imports: tools, utils, foreign, haven, longurl, openxlsx, readODS, jsonlite, XML, curl (>= 0.6), data.table (>= 1.9.5), readxl, yaml, dplyr
 Suggests: bit64, testthat, knitr, magrittr
 License: GPL-2
 VignetteBuilder: knitr

--- a/R/export.R
+++ b/R/export.R
@@ -63,6 +63,30 @@ export.clipboard <- function(x, row.names = FALSE, col.names = TRUE, sep = "\t",
     }
 }
 
+export.sql <- function(x, table, db_type, ...){
+    switch(db_type,
+           mysql = export.mysql(...),
+           postgresql = import.pg(...),
+           sqlite = import.sqlite(...),
+           stop("Unrecognized file format"))
+}
+
+export.mysql <- function(x, table, dbname, host, port, username, password){
+  db <- dplyr::src_mysql(dbname, host, port, username, password)
+  dbWriteTable(db, value = x, name = table, append = T, row.names = FALSE)
+}
+
+
+export.pg <- function(x, table, dbname, host, port, username, password){
+  db <- dplyr::src_postgres(dbname, host, port, username, password)
+  dbWriteTable(db, value = x, name = table, append = T, row.names = FALSE)
+}
+
+export.sqlite <- function(x, table, file){
+  db <- dplyr::src_sqlite(path = file)
+  dbWriteTable(db, value = x, name = table, append = T, row.names = FALSE)
+}
+           
 export <- function(x, file, format, ...) {
     if(missing(file) & missing(format)) {
         stop("Must specify 'file' and/or 'format'")

--- a/R/export.R
+++ b/R/export.R
@@ -66,8 +66,8 @@ export.clipboard <- function(x, row.names = FALSE, col.names = TRUE, sep = "\t",
 export.sql <- function(x, table, db_type, ...){
     switch(db_type,
            mysql = export.mysql(...),
-           postgresql = import.pg(...),
-           sqlite = import.sqlite(...),
+           postgresql = export.pg(...),
+           sqlite = export.sqlite(...),
            stop("Unrecognized file format"))
 }
 

--- a/R/import.R
+++ b/R/import.R
@@ -163,7 +163,7 @@ import.clipboard <- function(header = TRUE, sep = "\t", ...) {
     }
 }
 
-import.sql <- function(){
+import.sql <- function(db_type){
     switch(db_type,
            mysql = import.mysql(),
            postgresql = import.pg(),
@@ -172,29 +172,18 @@ import.sql <- function(){
 }
 
 import.mysql <- function(dbname, host, port, username, password, table, ...){
-  if (!requireNamespace("dplyr", quitely = TRUE)){
-    stop('dplyr package required to connect to MySQL sources', call. = FALSE)
-  }
-  library(dplyr)
   db <- dplyr::src_mysql(dbname, host, port, username, password)
   result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
   result
 }
 
 import.pg <- function(dbname, host, port, username, password, table, ...){
-  if (!requireNamespace("dplyr", quitely = TRUE)){
-    stop('dplyr package required to connect to PostgreSQL sources', call. = FALSE)
-  }
-  library(dplyr)
   db <- dplyr::src_postgres(dbname, host, port, username, password)
   result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
   result
 }
 
 import.sqlite <- function(file, table, ...){
-  if (!requireNamespace("dplyr", quitely = TRUE)){
-    stop('dplyr package required to connect to SQLite sources', call. = FALSE)
-  }
   db <- dplyr::src_sqlite(path = file)
   result <- dplyr::tbl(db, from = table, ...)
   result

--- a/R/import.R
+++ b/R/import.R
@@ -163,6 +163,43 @@ import.clipboard <- function(header = TRUE, sep = "\t", ...) {
     }
 }
 
+import.sql <- function(){
+    switch(db_type,
+           mysql = import.mysql(),
+           postgresql = import.pg(),
+           sqlite = import.sqlite(),
+           stop("Unrecognized file format"))
+}
+
+import.mysql <- function(dbname, host, port, username, password, table, ...){
+  if (!requireNamespace("dplyr", quitely = TRUE)){
+    stop('dplyr package required to connect to MySQL sources', call. = FALSE)
+  }
+  library(dplyr)
+  db <- dplyr::src_mysql(dbname, host, port, username, password)
+  result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
+  result
+}
+
+import.pg <- function(dbname, host, port, username, password, table, ...){
+  if (!requireNamespace("dplyr", quitely = TRUE)){
+    stop('dplyr package required to connect to PostgreSQL sources', call. = FALSE)
+  }
+  library(dplyr)
+  db <- dplyr::src_postgres(dbname, host, port, username, password)
+  result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
+  result
+}
+
+import.sqlite <- function(file, table, ...){
+  if (!requireNamespace("dplyr", quitely = TRUE)){
+    stop('dplyr package required to connect to SQLite sources', call. = FALSE)
+  }
+  db <- dplyr::src_sqlite(path = file)
+  result <- dplyr::tbl(db, from = table, ...)
+  result
+}
+
 import <- function(file, format, setclass, expandurl = TRUE, ...) {
     if(grepl("^http.*://", file)) {
         if(missing(format)) {
@@ -220,6 +257,7 @@ import <- function(file, format, setclass, expandurl = TRUE, ...) {
                 ods = import.ods(file = file, ...),
                 xml = import.xml(file = file, ...),
                 clipboard = import.clipboard(...),
+                sql = import.sql(...),
                 # unsupported formats
                 tar = stop(stop_for_import(fmt)),
                 zip = stop(stop_for_import(fmt)),

--- a/R/import.R
+++ b/R/import.R
@@ -163,29 +163,29 @@ import.clipboard <- function(header = TRUE, sep = "\t", ...) {
     }
 }
 
-import.sql <- function(db_type){
+import.sql <- function(x, db_type, ...){
     switch(db_type,
-           mysql = import.mysql(),
-           postgresql = import.pg(),
-           sqlite = import.sqlite(),
+           mysql = import.mysql(x, ...),
+           postgresql = import.pg(x, ...),
+           sqlite = import.sqlite(x, ...),
            stop("Unrecognized file format"))
 }
 
-import.mysql <- function(dbname, host, port, username, password, table, ...){
+import.mysql <- function(x, dbname, host, port, username, password, ...){
   db <- dplyr::src_mysql(dbname, host, port, username, password)
-  result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
+  result <- dplyr::collect(dplyr::tbl(db, from = x, ...))
   result
 }
 
-import.pg <- function(dbname, host, port, username, password, table, ...){
+import.pg <- function(x, dbname, host, port, username, password, ...){
   db <- dplyr::src_postgres(dbname, host, port, username, password)
-  result <- dplyr::collect(dplyr::tbl(db, from = table, ...))
+  result <- dplyr::collect(dplyr::tbl(db, from = x, ...))
   result
 }
 
-import.sqlite <- function(file, table, ...){
+import.sqlite <- function(x, file, ...){
   db <- dplyr::src_sqlite(path = file)
-  result <- dplyr::tbl(db, from = table, ...)
+  result <- dplyr::tbl(db, from = x, ...)
   result
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,7 +53,8 @@ get_type <- function(fmt) {
         mat = "matlab",
         matlab = "matlab",
         gexf = "gexf",
-        npy = "npy"
+        npy = "npy",
+        sql = "sql"
     )
     type <- type_list[[tolower(fmt)]]
     if(is.null(type)) {


### PR DESCRIPTION
This adds import.sql, import.pg, import.mysql, and import.sqlite. They
are all aliases to dplyr's src_* family of database functions and
require:

* The arguments used to connect to a database source, such as host,
port, username, and password for non-sqlite and file path for sqlite.

* A `table` argument that specifies the table to collect into a local
data.frame.

In the future, we can remove the `from = table` and replace with
something like `sql(...)` tbl() will allow an arbitrary sql statement
as a string.