### PR TITLE
make sure cleanup.haven does exact matching on attribute names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -84,8 +84,8 @@ get_ext <- function(file) {
 }
 
 cleanup.haven <- function(x) {
-    xinfo <- list(var.labels = sapply(x, attr, which = "label"),
-                  label.table = sapply(x, attr, which = "labels"))
+    xinfo <- list(var.labels = sapply(x, attr, which = "label", exact = TRUE),
+                  label.table = sapply(x, attr, which = "labels", exact = TRUE))
     discrete <- sapply(x, function(y) length(unique(attr(y, "labels"))) >= length(na.omit(unique(y))))
     x[discrete] <- lapply(x[discrete], as_factor)
     x[sapply(x, is.numeric)] <- lapply(x[sapply(x, is.numeric)], function(y) {


### PR DESCRIPTION
There is a potential problem if a variable has value labels but no variable label, as indicated by http://comments.gmane.org/gmane.comp.lang.r.general/325629. This PR makes sure that matching is done exactly so that `labels` will not be mistakenly returned as `label`.