### PR TITLE
Fix failing test for get_type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A Swiss-Army Knife for Data I/O
 Version: 0.3.3
 Date: 2016-02-10
 Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
-Authors@R: c(person("Jason", "Becker", role = "aut"),
+Authors@R: c(person("Jason", "Becker", role = "aut", email = "jason@jbecker.co"),
              person("Chung-hong", "Chan", role = "aut", email = "chainsawtiney@gmail.com"),
              person("Geoffrey CH", "Chan", role = "aut", email = "gefchchan@gmail.com"),
              person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,7 +60,7 @@ get_type <- function(fmt) {
     out <- type_list[[tolower(fmt)]]
     if (is.null(out)) {
         message("Unrecognized file format. Try specifying with the format argument.")
-        return(type)
+        return(fmt)
     }
     return(out)
 }

--- a/tests/testthat/test_errors.R
+++ b/tests/testthat/test_errors.R
@@ -10,8 +10,10 @@ test_that("Error for unsupported file types", {
     writeLines("123", con = "test.faketype")
     expect_error(import("test.faketype"), "Unrecognized file format")
     expect_error(export(mtcars, "mtcars.faketype"), "Unrecognized file format")
-    expect_error(get_type("faketype"), "Unrecognized file format. Try specifying with the format argument.")
+    expect_message(get_type("faketype"), "Unrecognized file format. Try specifying with the format argument.")
+    expect_equal(get_type("faketype"), "faketype")
     expect_error(get_ext("noextension"), "'file' has no extension")
+    unlink("test.faketype")
 })
 
 test_that("Error for mixed support file types", {


### PR DESCRIPTION
## Why?
`get_type()` no longer raises an error when the type is not returned. Instead, the extension/format passed to `get_type()` is returned with a message. Instead, `.import.default()` and `.export.default()` raise the error.

## How does this PR address this need?

This changes back the element returned by `get_data()` in the unmatched case to `fmt`, and changes the tests to `expect_message()` and make sure unmatched are passed through untouched.

Additionally, I added my email address to the contributors and removed the `test.faketype` file after the test is complete.