### PR TITLE
Fixes failing build test for Import from CSVY

### DIFF
--- a/tests/testthat/test_import.R
+++ b/tests/testthat/test_import.R
@@ -10,7 +10,7 @@ test_that("Import from CSVY", {
     expect_true(inherits(d, "data.frame"))
     
     d2 <- import(system.file("examples", "example2.csvy", package = "rio"))
-    expect_true(c("title", "units", "source") %in% names(attributes(d2)))
+    expect_true(all(c("title", "units", "source") %in% names(attributes(d2))))
 })
 #test_that("Import from PSV", {})
 #test_that("Import from FWF", {})


### PR DESCRIPTION
## Why?

`expect_true` expects a single-element vector of `TRUE` or `FALSE`, and the test as written results in `c(TRUE, TRUE, TRUE`.

## How does this PR address this?

I added `all()` as a wrapper on tne result.