### PR TITLE
minor changes to exporting csvy

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -26,10 +26,13 @@ export_delim <- function(file, x, sep = "\t", row.names = FALSE,
     a <- attributes(x)
     a <- a[!names(a) %in% "row.names"]
     
-    m <- paste0("---\n", as.yaml(a), "---\n")
+    y <- paste0("---\n", as.yaml(a), "---\n")
     
-    y <- paste0("#", readLines(textConnection(m)),
-                collapse = "\n")
+    if (isTRUE(comment_header)){
+      m <- readLines(textConnection(y))
+      y <- paste0("#", m[-length(m)],collapse = "\n")
+      y <- c(y, "\n")
+    }
     cat(y, file = file)
     
     # append CSV

--- a/R/export.R
+++ b/R/export.R
@@ -25,7 +25,11 @@ export_delim <- function(file, x, sep = "\t", row.names = FALSE,
     # write yaml
     a <- attributes(x)
     a <- a[!names(a) %in% "row.names"]
-    y <- paste0("#", paste0("---\n", as.yaml(a), "---\n"))
+    
+    m <- paste0("---\n", as.yaml(a), "---\n")
+    
+    y <- paste0("#", readLines(textConnection(m)),
+                collapse = "\n")
     cat(y, file = file)
     
     # append CSV


### PR DESCRIPTION
when I was experimenting with exporting `.csvy` files, I found that only the first line (not all lines) of the header were being commented. Also, the argument `comment_header` didn't seem to alter this behaviour. These changes bring the function's behaviour closer to that described in the documentation (as far as I understand it)