### PR TITLE
Use gcc-4.9 to compile code for C++11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: r
-sudo: required
-r_check_revdep: false
+sudo: false
+cache: packages
+
 r_packages:
-- covr
-r_binary_packages:
-- BH
-- stringi
-r_github_packages:
-- wesm/feather/R
+  - covr
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+
+before_install: |
+  mkdir ~/.R
+  cat <<EOF > ~/.R/Makevars
+  CXX=g++-4.9
+  CXX1X=g++-4.9
+  CXX1XSTD=-std=c++11
+
 after_success:
-- Rscript -e 'library("covr");codecov()'
+  - Rscript -e 'library("covr");codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,5 +36,7 @@ Suggests:
     testthat, 
     knitr, 
     magrittr
+Remotes:
+  wesm/feather/R
 License: GPL-2
 VignetteBuilder: knitr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ init:
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 
+environment:
+  global:
+    USE_RTOOLS: true
+
 install:
   ps: Bootstrap
 


### PR DESCRIPTION
This is admittedly painful, and I am not positive the heredoc syntax will work as written in yaml.