### PR TITLE
Solve decimal separator issue (#106)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co")
              person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com"),
              person("Christopher", "Gandrud", role = "ctb"),
              person("Andrew", "MacDonald", role = "ctb"),
-             person("Ista", "Zahn", role = "ctb"))
+             person("Ista", "Zahn", role = "ctb“),
+person(„Stanislaus“, „Stadlmann“, role = "ctb"))
 Description: Streamlined data import and export by making assumptions that the user is probably willing to make: 'import()' and 'export()' determine the data structure from the file extension, reasonable defaults are used for data import and export (e.g., 'stringsAsFactors=FALSE'), web-based import is natively supported (including from SSL/HTTPS), compressed files can be read directly without explicit decompression, and fast import packages are used where appropriate.
 Depends: R (>= 2.15.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,7 @@ Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co")
              person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com"),
              person("Christopher", "Gandrud", role = "ctb"),
              person("Andrew", "MacDonald", role = "ctb"),
-             person("Ista", "Zahn", role = "ctb“),
-person(„Stanislaus“, „Stadlmann“, role = "ctb"))
+             person("Ista", "Zahn", role = "ctb"), person("Stanislaus", "Stadlmann", role = "ctb"))
 Description: Streamlined data import and export by making assumptions that the user is probably willing to make: 'import()' and 'export()' determine the data structure from the file extension, reasonable defaults are used for data import and export (e.g., 'stringsAsFactors=FALSE'), web-based import is natively supported (including from SSL/HTTPS), compressed files can be read directly without explicit decompression, and fast import packages are used where appropriate.
 Depends: R (>= 2.15.0)
 Imports:

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -1,4 +1,4 @@
-import_delim <- function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto", header = "auto", stringsAsFactors = FALSE, data.table = FALSE, ...) {
+import_delim <- function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto", header = "auto", stringsAsFactors = FALSE, data.table = FALSE, dec = ".", ...) {
   if (fread) {
     fread(input = file, sep = sep, sep2 = sep2, header = header, stringsAsFactors = stringsAsFactors, data.table = data.table, ...)
   } else {
@@ -8,10 +8,21 @@ import_delim <- function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "au
     if (missing(header) || is.null(header) || header == "auto") {
       header <- TRUE
     }
-    if (missing(sep2) || is.null(sep2) || sep2 == "auto") {
-      sep2 <- "."
+    
+    # If dec is not specified but sep2 is, take sep2
+    if (is.null(dec) && !is.null(sep2) && sep2 != "auto") {
+      dec <- sep2
     }
-    read.table(file = file, sep = sep, dec = sep2, header = header, stringsAsFactors = stringsAsFactors, ...)
+    
+    # Override argument
+    call <- match.call()[1]
+    call[[1]] <- as.name("read.table")
+    call$file <- file
+    call$sep <- sep
+    call$dec <- dec # important part
+    call$header <- header
+    call$stringsAsFactors <- stringsAsFactors
+    eval(call)
   }
 }
 

--- a/tests/testthat/test_format_csv.R
+++ b/tests/testthat/test_format_csv.R
@@ -11,6 +11,13 @@ test_that("Import from CSV", {
     expect_that(colnames(noheadercsv)[1], equals("V1"), label = "Header is correctly specified")
 })
 
+test_that("Import from CSV with comma separator", {
+  name <- "iris_comma_sep.csv"
+  write.table(iris, name, dec = ",", sep = ";")
+  expect_true(name %in% dir())
+  expect_true(is.data.frame(import("iris_comma_sep.csv", dec = ",", sep = ";", fread = FALSE, header = TRUE)))
+})
+
 context("CSV (.csv2) imports/exports")
 
 test_that("Export to CSV", {


### PR DESCRIPTION
Hi Thomas,

this is my PR to solve #106. It basically overrides the original sep argument of `read.table()` and therefore solves the issue of not allowing for a comma separator. The decimal separator error also appears when `fread = TRUE`, but because `fread()` itself has issues of dealing with the comma separator, I only provided a solution for `read.table()` or `import(fread = FALSE)`.

The test file I used where I got my errors can be downloaded [here](https://www.dropbox.com/s/0q1ve5yly94f8ya/csv_food_supply.csv?dl=0). After this PR, both `rio::import()` and `rio:::import_delim()` can deal with `sep = ","`.

Please let me know if you want me to implement this solution for `fread = TRUE` as well.

All the Best,
Stani