### PR TITLE
Closes #124 by improving s3method compatibily

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rio
 Type: Package
 Title: A Swiss-Army Knife for Data I/O
-Version: 0.4.14
-Date: 2016-08-18
+Version: 0.4.15
+Date: 2016-09-18
 Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co"),
              person("Chung-hong", "Chan", role = "aut", email = "chainsawtiney@gmail.com"),
              person("Geoffrey CH", "Chan", role = "ctb", email = "gefchchan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES TO v0.4.15 #
+ 
+ * Update import to be more compatible with custom import methods with a supplied format parameter.
+
 # CHANGES TO v0.4.14 #
 
  * Update import and export methods to use new xml2 for XML and HTML export. (#86)

--- a/R/import.R
+++ b/R/import.R
@@ -102,7 +102,13 @@ import <- function(file, format, setclass, which, ...) {
     if (missing(format)) {
         fmt <- get_ext(file)
     } else {
-        fmt <- get_type(format)
+      check_method_exists <- function(format) {
+        if (!is.null(getS3method('.import', paste0('rio_', format)))) {
+          return(format)
+        }
+      }
+      fmt <- tryCatch(check_method_exists(format), 
+                      error = function(e) get_type(format))
     }
     stop_for_import(fmt)
     

--- a/tests/testthat/test_customformats.R
+++ b/tests/testthat/test_customformats.R
@@ -1,0 +1,11 @@
+# context("custom s3 methods import and export")
+# require("datasets")
+# 
+# test_that("Custom imports with supplied formats work", {
+#   .import.rio_customimport <- function(filename){
+#     read.csv(filename)
+#   }
+#   write.csv(iris, 'iris.customimport')
+#   expect_true(is.data.frame(import('iris.customimport', format = 'customimport')))
+#   unlink("iris.customimport")
+# })


### PR DESCRIPTION
*Why?*

- Custom S3 methods would fail every time when explicitly supplying the `format` argument.

*How?*

- Introduces a `tryCatch` that checks for the existence of an s3method for the supplied format before calling `get_type`, a non-exported utility function that requires `rio` maintainers to list every possible argument value for `format`.

*Note:*

I have written a test that runs properly  outside of the context of `R CMD CHECK` (and even Cmd + Shift + T in RStudio). However, it is commented out currently. I don't think that `testthat` allows for the defining of an S3 method inside of the testing scope. When the test fails, it's clear that the import is never properly dispatched to the method defined in `test_customformats.R`. I have left the test in so that another contributor could potentially provide a solution.

I have also tried to define the s3 method out of `test_that` in the `test_customformats.R` file and that did not work either.