### PR TITLE
sheet/which

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rio
 Type: Package
 Title: A Swiss-Army Knife for Data I/O
-Version: 0.4.19
-Date: 2016-12-05
+Version: 0.4.20
+Date: 2016-12-07
 Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co"),
              person("Chung-hong", "Chan", role = "aut", email = "chainsawtiney@gmail.com"),
              person("Geoffrey CH", "Chan", role = "ctb", email = "gefchchan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES TO v0.4.20
 
- * Fixed a big in the `.import.rio_xls()` and `.import.rio_xlsx()` where the `sheet` argument would not be not be passed to `which` and would return an error. 
+ * Fixed a big in the `.import.rio_xls()` and `.import.rio_xlsx()` where the `sheet` argument would return an error.
 
 # CHANGES TO v0.4.19
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES TO v0.4.20
+
+ * Fixed a big in the `.import.rio_xls()` and `.import.rio_xlsx()` where the `sheet` argument would not be not be passed to `which` and would return an error. 
+
 # CHANGES TO v0.4.19
 
  * Fixed a bug in the import of delimited files when `fread = FALSE`. (#133, h/t Christopher Gandrud)
@@ -197,7 +201,7 @@
 
 # CHANGES TO v0.2.2
 
- * Uses the longurl package to expand shortened URLs so that their file type can be easily determined. 
+ * Uses the longurl package to expand shortened URLs so that their file type can be easily determined.
 
 # CHANGES TO v0.2.1
 

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -1,9 +1,9 @@
 #' @importFrom data.table fread
-import_delim <- 
-function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto", 
+import_delim <-
+function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto",
          header = "auto", stringsAsFactors = FALSE, data.table = FALSE, ...) {
     if (isTRUE(fread) & !inherits(file, "connection")) {
-        fread(input = file, sep = sep, sep2 = sep2, header = header, 
+        fread(input = file, sep = sep, sep2 = sep2, header = header,
               stringsAsFactors = stringsAsFactors, data.table = data.table, ...)
     } else {
         if (inherits(file, "connection")) {
@@ -159,9 +159,9 @@ function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto",
 #' @importFrom foreign read.dta
 #' @importFrom haven read_dta
 #' @export
-.import.rio_dta <- function(file, haven = TRUE, 
-                            convert.dates = TRUE, 
-                            convert.factors = FALSE, 
+.import.rio_dta <- function(file, haven = TRUE,
+                            convert.dates = TRUE,
+                            convert.factors = FALSE,
                             missing.type = FALSE, ...) {
   if (haven) {
     a <- list(...)
@@ -170,9 +170,9 @@ function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto",
     }
     convert_attributes(read_dta(file = file))
   } else {
-    out <- read.dta(file = file, 
-                    convert.dates = convert.dates, 
-                    convert.factors = convert.factors, 
+    out <- read.dta(file = file,
+                    convert.dates = convert.dates,
+                    convert.factors = convert.factors,
                     missing.type = missing.type, ...)
     attr(out, "expansion.fields") <- NULL
     attr(out, "time.stamp") <- NULL
@@ -199,7 +199,7 @@ function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto",
   if (haven) {
     convert_attributes(read_sav(file = file))
   } else {
-    convert_attributes(read.spss(file = file, to.data.frame = to.data.frame, 
+    convert_attributes(read.spss(file = file, to.data.frame = to.data.frame,
                                  use.value.labels = use.value.labels, ...))
   }
 }
@@ -255,22 +255,42 @@ function(file, which = 1, fread = TRUE, sep = "auto", sep2 = "auto",
 #' @importFrom readxl read_excel
 #' @export
 .import.rio_xls <- function(file, which = 1, ...) {
-  read_excel(path = file, sheet = which, ...)
+
+  Call <- match.call(expand.dots = TRUE)
+  if ("which" %in% names(Call)) {
+    Call$sheet <- Call$which
+    Call$which <- NULL
+  }
+
+  Call$path <- file
+  Call$file <- NULL
+  Call$readxl <- NULL
+  Call[[1L]] <- as.name("read_excel")
+  eval.parent(Call)
 }
 
 #' @importFrom readxl read_excel
 #' @importFrom openxlsx read.xlsx
 #' @export
 .import.rio_xlsx <- function(file, which = 1, readxl = TRUE, ...) {
-  a <- list(...)
-  if ("sheet" %in% names(a)) {
-        which <- a$sheet
+
+  Call <- match.call(expand.dots = TRUE)
+  if ("which" %in% names(Call)) {
+    Call$sheet <- Call$which
+    Call$which <- NULL
   }
+
   if (readxl) {
-    read_excel(path = file, sheet = which, ...)
+    Call$path <- file
+    Call[[1L]] <- as.name("read_excel")
   } else {
-    read.xlsx(xlsxFile = file, sheet = which, ...)
+    Call$xlsxFile <- file
+    Call[[1L]] <- as.name("read.xlsx")
   }
+
+  Call$file <- NULL
+  Call$readxl <- NULL
+  eval.parent(Call)
 }
 
 #' @importFrom utils read.fortran

--- a/tests/testthat/test_format_xls.R
+++ b/tests/testthat/test_format_xls.R
@@ -12,6 +12,8 @@ test_that("Export to Excel (.xlsx)", {
 test_that("Import from Excel (.xlsx)", {
     expect_true(is.data.frame(import("iris.xlsx", readxl = FALSE)))
     expect_true(is.data.frame(import("iris.xlsx", readxl = TRUE)))
+    expect_true(is.data.frame(import("iris.xlsx", sheet = 1)))
+    expect_true(is.data.frame(import("iris.xlsx", which = 1)))
 })
 
 unlink("iris.xlsx")


### PR DESCRIPTION
Fixes a bug in `.import.rio_xls` and `.import.rio_xlsx` where a user supplying `sheet` rather than `which` would cause an error: `formal argument "sheet" matched by multiple actual arguments`.

There was an attempt made in the previous version to pass on the the contents of `sheet` to `which`. However, this left `sheet` in the dots and so `sheet` was supplied twice to the `read_excel`  call thus causing the above error. 

This pull request solves this problem, allowing a user to supply `sheet` without it causing an error and instead being passed to `which`. I also added a test of this for `.import.rio_xlsx` in `test_format_xls.R`