### PR TITLE
These changes seem to get .csv.gz files working in rio

### DIFF
--- a/R/export_methods.R
+++ b/R/export_methods.R
@@ -2,10 +2,13 @@
 #' @importFrom utils write.table
 export_delim <- function(file, x, fwrite = TRUE, sep = "\t", row.names = FALSE,
                          col.names = TRUE, ...) {
-    if (fwrite) {
+    if (isTRUE(fwrite) & !inherits(file, "connection")) {
         fwrite(x, file = file, sep = sep, col.name = col.names,
                row.names = row.names, ...)
     } else {
+        if (isTRUE(fwrite) & inherits(file, "connection")) {
+            message("data.table::fwrite() does not support writing to connections. Using utils::write.table() instead.")
+        }
         write.table(x, file = file, sep = sep, row.names = row.names,
                     col.names = col.names, ...)
     }

--- a/R/import.R
+++ b/R/import.R
@@ -106,8 +106,7 @@ import <- function(file, format, setclass, which, ...) {
         fmt <- get_ext(file)
         if (fmt %in% c("gz", "gzip")) {
             fmt <- file_ext(file_path_sans_ext(file, compression = FALSE))
-            file <- gzfile(file, "r")
-            on.exit(close(file))
+            file <- gzfile(file)
         }
     } else {
         fmt <- get_type(format)

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -11,7 +11,7 @@ function(file, which = 1, fread = TRUE, sep = "auto",
         dots[["data.table"]] <- data.table
         do.call("fread", dots)
     } else {
-        if (inherits(file, "connection")) {
+        if (isTRUE(fread) & inherits(file, "connection")) {
             message("data.table::fread() does not support reading from connections. Using utils::read.table() instead.")
         }
         dots <- list(...)


### PR DESCRIPTION
Should close #123 

Not sure why there is such a behavior difference in ``read.table`` when using ``gzfile(file)`` directly instead of ``gzifle(file, 'r')`` but the former doesn't cause in warnings on my machine...

