### PR TITLE
Update supported formats lists

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -13,29 +13,29 @@
 #' \code{export} supports many file formats. See the documentation for the underlying export functions for optional arguments that can be passed via \code{...}
 #'
 #' \itemize{
-#'     \item Tab-separated data (.tsv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
 #'     \item Comma-separated data (.csv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
-#'     \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
-#'     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (\#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
 #'     \item Pipe-separated data (.psv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{sep = '|'} and \code{row.names = FALSE}.
-#'     \item Feather R/Python interchange format (.feather), using \code{feather::write_feather}
-#'     \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
-#'     \item Fixed-width format data (.fwf), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}, \code{quote = FALSE}, and \code{col.names = FALSE}
-#'     \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
-#'     \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
-#'     \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
-#'     \item YAML (.yml), using \code{\link[yaml]{as.yaml}}
-#'     \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-#'     \item SPSS (.sav), using \code{\link[haven]{write_sav}}
+#'     \item Tab-separated data (.tsv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
 #'     \item SAS (.sas7bdat), using \code{\link[haven]{write_sas}}.
+#'     \item SPSS (.sav), using \code{\link[haven]{write_sav}}
+#'     \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
+#'     \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
+#'     \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'}
+#'     \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
+#'     \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
 #'     \item "XBASE" database files (.dbf), using \code{\link[foreign]{write.dbf}}
 #'     \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{write.arff}}
-#'     \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'}
+#'     \item Fixed-width format data (.fwf), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}, \code{quote = FALSE}, and \code{col.names = FALSE}
+#'     \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
+#'     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (\#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
+#'     \item Feather R/Python interchange format (.feather), using \code{feather::write_feather}
+#'     \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
+#'     \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
 #'     \item Matlab (.mat), using \code{\link[rmatio]{write.mat}}
-#'     \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
 #'     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{write_ods}}. (Currently only single-sheet exports are supported.)
-#'     \item XML (.xml), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple XML tree and \code{\link[xml2]{write_xml}} to write to disk.
 #'     \item HTML (.html), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple HTML table and \code{\link[xml2]{write_xml}} to write to disk.
+#'     \item XML (.xml), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple XML tree and \code{\link[xml2]{write_xml}} to write to disk.
+#'     \item YAML (.yml), using \code{\link[yaml]{as.yaml}}
 #'     \item Clipboard export (on Windows and Mac OS), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
 #' }
 #'

--- a/R/import.R
+++ b/R/import.R
@@ -12,36 +12,37 @@
 #' \code{import} supports the following file formats:
 #'
 #' \itemize{
-#'     \item Tab-separated data (.tsv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
 #'     \item Comma-separated data (.csv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+#'     \item Pipe-separated data (.psv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{sep = '|'}, \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+#'     \item Tab-separated data (.tsv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+#'     \item SAS (.sas7bdat), using \code{\link[haven]{read_sas}}.
+#'     \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
+#'     \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
+#'     \item SAS XPORT (.xpt), using \code{\link[foreign]{read.xport}}.
+#'     \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
+#'     \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. If \code{readxl = FALSE}, \code{\link[openxlsx]{read.xlsx}} can be used. Use \code{which} to specify a sheet number.
+#'     \item R syntax object (.R), using \code{\link[base]{dget}}
+#'     \item Saved R objects (.RData,.rda), using \code{\link[base]{load}} for single-object .Rdata files. Use \code{which} to specify an object name for multi-object .Rdata files.
+#'     \item Serialized R objects (.rds), using \code{\link[base]{readRDS}}
+#'     \item Epiinfo (.rec), using \code{\link[foreign]{read.epiinfo}}
+#'     \item Minitab (.mtp), using \code{\link[foreign]{read.mtp}}
+#'     \item Systat (.syd), using \code{\link[foreign]{read.systat}}
+#'     \item "XBASE" database files (.dbf), using \code{\link[foreign]{read.dbf}}
+#'     \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{read.arff}}
+#'     \item Data Interchange Format (.dif), using \code{\link[utils]{read.DIF}}
+#'     \item Fortran data (no recognized extension), using \code{\link[utils]{read.fortran}}
+#'     \item Fixed-width format data (.fwf), using a faster version of \code{\link[utils]{read.fwf}} that requires a \code{widths} argument and by default in rio has \code{stringsAsFactors = FALSE}. If \code{readr = TRUE}, import will be performed using \code{\link[readr]{read_fwf}}, where \code{widths} should be: \code{NULL}, a vector of column widths, or the output of \code{\link[readr]{fwf_empty}}, \code{\link[readr]{fwf_widths}}, or \code{\link[readr]{fwf_positions}}.
 #'     \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
 #'     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{read_csvy}}.
 #'     \item Feather R/Python interchange format (.feather), using \code{feather::read_feather}
 #'     \item Fast storage (.fst), using \code{\link[fst]{read.fst}}
-#'     \item Pipe-separated data (.psv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{sep = '|'}, \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
-#'     \item Fixed-width format data (.fwf), using a faster version of \code{\link[utils]{read.fwf}} that requires a \code{widths} argument and by default in rio has \code{stringsAsFactors = FALSE}. If \code{readr = TRUE}, import will be performed using \code{\link[readr]{read_fwf}}, where \code{widths} should be: \code{NULL}, a vector of column widths, or the output of \code{\link[readr]{fwf_empty}}, \code{\link[readr]{fwf_widths}}, or \code{\link[readr]{fwf_positions}}.
-#'     \item Serialized R objects (.rds), using \code{\link[base]{readRDS}}
-#'     \item Saved R objects (.RData,.rda), using \code{\link[base]{load}} for single-object .Rdata files. Use \code{which} to specify an object name for multi-object .Rdata files.
 #'     \item JSON (.json), using \code{\link[jsonlite]{fromJSON}}
-#'     \item YAML (.yml), using \code{\link[yaml]{yaml.load}}
-#'     \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
-#'     \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
-#'     \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
-#'     \item "XBASE" database files (.dbf), using \code{\link[foreign]{read.dbf}}
-#'     \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{read.arff}}
-#'     \item R syntax object (.R), using \code{\link[base]{dget}}
 #'     \item Matlab (.mat), using \code{\link[rmatio]{read.mat}}
-#'     \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. If \code{readxl = FALSE}, \code{\link[openxlsx]{read.xlsx}} can be used. Use \code{which} to specify a sheet number.
-#'     \item SAS (.sas7bdat) and SAS XPORT (.xpt), using \code{\link[haven]{read_sas}} and \code{\link[foreign]{read.xport}}.
-#'     \item Minitab (.mtp), using \code{\link[foreign]{read.mtp}}
-#'     \item Epiinfo (.rec), using \code{\link[foreign]{read.epiinfo}}
-#'     \item Systat (.syd), using \code{\link[foreign]{read.systat}}
-#'     \item Data Interchange Format (.dif), using \code{\link[utils]{read.DIF}}
 #'     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{read_ods}}.  Use \code{which} to specify a sheet number.
-#'     \item Shallow XML documents (.xml), using \code{\link[xml2]{read_xml}}. The data structure will only be read correctly if the XML file can be converted to a list via \code{\link[xml2]{as_list}}.
 #'     \item Single-table HTML documents (.html), using \code{\link[xml2]{read_html}}. The data structure will only be read correctly if the HTML file can be converted to a list via \code{\link[xml2]{as_list}}.
+#'     \item Shallow XML documents (.xml), using \code{\link[xml2]{read_xml}}. The data structure will only be read correctly if the XML file can be converted to a list via \code{\link[xml2]{as_list}}.
+#'     \item YAML (.yml), using \code{\link[yaml]{yaml.load}}
 #'     \item Clipboard import (on Windows and Mac OS), using \code{\link[utils]{read.table}} with \code{row.names = FALSE}
-#'     \item Fortran data (no recognized extension), using \code{\link[utils]{read.fortran}}
 #'     \item Google Sheets, as Comma-separated data (.csv)
 #' }
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -82,7 +82,7 @@ unlink("mtcars.tsv.zip")
 
 ## Supported file formats
 
-**rio** supports a variety of different file formats for import and export. To keep the package slim, all non-essential formats are supported via "Suggests" packages, which are not installed (or loaded) by default. To ensure rio is fully functional, install these packages the first time you use **rio** via:
+**rio** supports a wide range of file formats. To keep the package slim, all non-essential formats are supported via "Suggests" packages, which are not installed (or loaded) by default. To ensure rio is fully functional, install these packages the first time you use **rio** via:
 
 ```R
 install_formats()
@@ -90,41 +90,41 @@ install_formats()
 
 The full list of supported formats is below:
 
-| Format | Import | Export |
-| ------ | ------ | ------ |
-| Tab-separated data (.tsv) | Yes | Yes |
-| Comma-separated data (.csv) | Yes | Yes |
-| gzip comma-separated data (.csv.gz) | Yes | Yes |
-| CSVY (CSV + YAML metadata header) (.csvy) | Yes | Yes |
-| Feather R/Python interchange format (.feather) | Yes | Yes |
-| Fast Storage (.fst) | Yes | Yes |
-| Pipe-separated data (.psv) | Yes | Yes |
-| Fixed-width format data (.fwf) | Yes | Yes |
-| Serialized R objects (.rds) | Yes | Yes |
-| Saved R objects (.RData,.rda) | Yes | Yes |
-| JSON (.json) | Yes | Yes |
-| YAML (.yml) | Yes | Yes |
-| Stata (.dta) | Yes | Yes |
-| SPSS (.sav) | Yes | Yes |
-| SPSS Portable (.por) | Yes |  |
-| "XBASE" database files (.dbf) | Yes | Yes |
-| Excel (.xls) | Yes |  |
-| Excel (.xlsx) | Yes | Yes |
-| Matlab (.mat) | Yes | Yes |
-| OpenDocument Spreadsheet  (.ods) | Yes | Yes |
-| Weka Attribute-Relation File Format (.arff) | Yes | Yes |
-| R syntax (.R) | Yes | Yes |
-| Shallow XML documents (.xml) | Yes | Yes |
-| HTML Tables (.html) | Yes | Yes |
-| SAS (.sas7bdat) | Yes | Yes |
-| SAS XPORT (.xpt) | Yes |  |
-| Minitab (.mtp) | Yes |  |
-| Epiinfo (.rec) | Yes |  |
-| Systat (.syd) | Yes |  |
-| Data Interchange Format (.dif) | Yes |  |
-| Fortran data (no recognized extension) | Yes |  |
-| [Google Sheets](https://www.google.com/sheets/about/) | Yes |  |
-| Clipboard (default is tsv) | Yes (uses [clipr](https://cran.r-project.org/package=clipr)) | Yes (uses [clipr](https://cran.r-project.org/package=clipr)) |
+| Format | Extension | Import Package | Export Package | Installed by Default |
+| ------ | --------- | -------------- | -------------- | -------------------- |
+| Comma-separated data | .csv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| Pipe-separated data | .psv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| Tab-separated data | .tsv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| SAS | .sas7bdat | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| SPSS | .sav | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| Stata | .dta | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| SAS XPORT | .xpt | [`haven`](https://cran.r-project.org/package=haven) |  | Yes |
+| SPSS Portable | .por | [`haven`](https://cran.r-project.org/package=haven) |  | Yes |
+| Excel | .xls | [`readxl`](https://cran.r-project.org/package=readxl) |  | Yes |
+| Excel | .xlsx | [`readxl`](https://cran.r-project.org/package=readxl) | [`openxlsx`](https://cran.r-project.org/package=openxlsx) | Yes / No |
+| R syntax | .R | `base` | `base` | Yes |
+| Saved R objects | .RData, .rda | `base` | `base` | Yes |
+| Serialized R objects | .rds | `base` | `base` | Yes |
+| Epiinfo | .rec | `foreign` |  | Yes |
+| Minitab | .mtp | `foreign` |  | Yes |
+| Systat | .syd | `foreign` |  | Yes |
+| "XBASE" database files | .dbf | `foreign` | `foreign` | Yes |
+| Weka Attribute-Relation File Format | .arff | `foreign` | `foreign` | Yes |
+| Data Interchange Format | .dif | `utils` |  | Yes |
+| Fortran data | no recognized extension | `utils` |  | Yes |
+| Fixed-width format data | .fwf | `utils` | `utils` | Yes |
+| gzip comma-separated data | .csv.gz | `utils` | `utils` | Yes |
+| CSVY (CSV + YAML metadata header) | .csvy | [`csvy`](https://cran.r-project.org/package=csvy) | [`csvy`](https://cran.r-project.org/package=csvy) | No |
+| Feather R/Python interchange format | .feather | [`feather`](https://cran.r-project.org/package=feather) | [`feather`](https://cran.r-project.org/package=feather) | No |
+| Fast Storage | .fst | [`fst`](https://cran.r-project.org/package=fst) | [`fst`](https://cran.r-project.org/package=fst) | No |
+| JSON | .json | [`jsonlite`](https://cran.r-project.org/package=jsonlite) | [`jsonlite`](https://cran.r-project.org/package=jsonlite) | No |
+| Matlab | .mat | [`rmatio`](https://cran.r-project.org/package=rmatio) | [`rmatio`](https://cran.r-project.org/package=rmatio) | No |
+| OpenDocument Spreadsheet | .ods | [`readODS`](https://cran.r-project.org/package=readODS) | [`readODS`](https://cran.r-project.org/package=readODS) | No |
+| HTML Tables | .html | [`xml2`](https://cran.r-project.org/package=xml2) | [`xml2`](https://cran.r-project.org/package=xml2) | No |
+| Shallow XML documents | .xml | [`xml2`](https://cran.r-project.org/package=xml2) | [`xml2`](https://cran.r-project.org/package=xml2) | No |
+| YAML | .yml | [`yaml`](https://cran.r-project.org/package=yaml) | [`yaml`](https://cran.r-project.org/package=yaml) | No |
+| Clipboard | default is tsv | [`clipr`](https://cran.r-project.org/package=clipr) | [`clipr`](https://cran.r-project.org/package=clipr) | No |
+| [Google Sheets](https://www.google.com/sheets/about/) | as Comma-separated data |  |  |  |
 
 Additionally, any format that is not supported by **rio** but that has a known R implementation will produce an informative error message pointing to a package and import or export function. Unrecognized formats will yield a simple "Unrecognized file format" error.
 
@@ -132,7 +132,7 @@ Additionally, any format that is not supported by **rio** but that has a known R
 
 The core advantage of **rio** is that it makes assumptions that the user is probably willing to make. Eight of these are important:
 
- 1. **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By taking away the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Other packages do this as well, but **rio** aims to be more complete and more consistent than each:
+ 1. **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By removing the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Other packages do this as well, but **rio** aims to be more complete and more consistent than each:
  
    - [**reader**](https://cran.r-project.org/package=reader) handles certain text formats and R binary files
    - [**io**](https://cran.r-project.org/package=io) offers a set of custom formats
@@ -151,7 +151,7 @@ The core advantage of **rio** is that it makes assumptions that the user is prob
  
  7. **rio** imports and exports files based on an internal S3 class infrastructure. This means that other packages can contain extensions to **rio** by registering S3 methods. These methods should take the form `.import.rio_X()` and `.export.rio_X()`, where `X` is the file extension of a file type. An example is provided in the [rio.db package](https://github.com/leeper/rio.db).
  
- 8. **rio** wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. It uses [**haven**](https://cran.r-project.org/package=haven) for reading and writing SAS, Stata, and SPSS files, [the `fread` function from **data.table**](https://cran.r-project.org/package=data.table) for delimited formats, smarter and faster fixed-width file import and export routines, and [**readxl**](https://cran.r-project.org/package=readxl) for reading from Excel workbooks.
+ 8. **rio** wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. It uses [**data.table**](https://cran.r-project.org/package=data.table) for delimited formats, [**haven**](https://cran.r-project.org/package=haven) for SAS, Stata, and SPSS files, smarter and faster fixed-width file import and export routines, and [**readxl**](https://cran.r-project.org/package=readxl) and [**openxlsx**](https://cran.r-project.org/package=openxlsx) for reading and writing Excel workbooks.
 
 ## Package Installation
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Rscript -e "rio::convert('iris.dta', 'iris.csv')"
 
 ## Supported file formats
 
-**rio** supports a variety of different file formats for import and export. To keep the package slim, all non-essential formats are supported via "Suggests" packages, which are not installed (or loaded) by default. To ensure rio is fully functional, install these packages the first time you use **rio** via:
+**rio** supports a wide range of file formats. To keep the package slim, all non-essential formats are supported via "Suggests" packages, which are not installed (or loaded) by default. To ensure rio is fully functional, install these packages the first time you use **rio** via:
 
 ```R
 install_formats()
@@ -126,41 +126,41 @@ install_formats()
 
 The full list of supported formats is below:
 
-| Format | Import | Export |
-| ------ | ------ | ------ |
-| Tab-separated data (.tsv) | Yes | Yes |
-| Comma-separated data (.csv) | Yes | Yes |
-| gzip comma-separated data (.csv.gz) | Yes | Yes |
-| CSVY (CSV + YAML metadata header) (.csvy) | Yes | Yes |
-| Feather R/Python interchange format (.feather) | Yes | Yes |
-| Fast Storage (.fst) | Yes | Yes |
-| Pipe-separated data (.psv) | Yes | Yes |
-| Fixed-width format data (.fwf) | Yes | Yes |
-| Serialized R objects (.rds) | Yes | Yes |
-| Saved R objects (.RData,.rda) | Yes | Yes |
-| JSON (.json) | Yes | Yes |
-| YAML (.yml) | Yes | Yes |
-| Stata (.dta) | Yes | Yes |
-| SPSS (.sav) | Yes | Yes |
-| SPSS Portable (.por) | Yes |  |
-| "XBASE" database files (.dbf) | Yes | Yes |
-| Excel (.xls) | Yes |  |
-| Excel (.xlsx) | Yes | Yes |
-| Matlab (.mat) | Yes | Yes |
-| OpenDocument Spreadsheet  (.ods) | Yes | Yes |
-| Weka Attribute-Relation File Format (.arff) | Yes | Yes |
-| R syntax (.R) | Yes | Yes |
-| Shallow XML documents (.xml) | Yes | Yes |
-| HTML Tables (.html) | Yes | Yes |
-| SAS (.sas7bdat) | Yes | Yes |
-| SAS XPORT (.xpt) | Yes |  |
-| Minitab (.mtp) | Yes |  |
-| Epiinfo (.rec) | Yes |  |
-| Systat (.syd) | Yes |  |
-| Data Interchange Format (.dif) | Yes |  |
-| Fortran data (no recognized extension) | Yes |  |
-| [Google Sheets](https://www.google.com/sheets/about/) | Yes |  |
-| Clipboard (default is tsv) | Yes (uses [clipr](https://cran.r-project.org/package=clipr)) | Yes (uses [clipr](https://cran.r-project.org/package=clipr)) |
+| Format | Extension | Import Package | Export Package | Installed by Default |
+| ------ | --------- | -------------- | -------------- | -------------------- |
+| Comma-separated data | .csv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| Pipe-separated data | .psv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| Tab-separated data | .tsv | [`data.table`](https://cran.r-project.org/package=data.table) | [`data.table`](https://cran.r-project.org/package=data.table) | Yes |
+| SAS | .sas7bdat | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| SPSS | .sav | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| Stata | .dta | [`haven`](https://cran.r-project.org/package=haven) | [`haven`](https://cran.r-project.org/package=haven) | Yes |
+| SAS XPORT | .xpt | [`haven`](https://cran.r-project.org/package=haven) |  | Yes |
+| SPSS Portable | .por | [`haven`](https://cran.r-project.org/package=haven) |  | Yes |
+| Excel | .xls | [`readxl`](https://cran.r-project.org/package=readxl) |  | Yes |
+| Excel | .xlsx | [`readxl`](https://cran.r-project.org/package=readxl) | [`openxlsx`](https://cran.r-project.org/package=openxlsx) | Yes / No |
+| R syntax | .R | `base` | `base` | Yes |
+| Saved R objects | .RData, .rda | `base` | `base` | Yes |
+| Serialized R objects | .rds | `base` | `base` | Yes |
+| Epiinfo | .rec | `foreign` |  | Yes |
+| Minitab | .mtp | `foreign` |  | Yes |
+| Systat | .syd | `foreign` |  | Yes |
+| "XBASE" database files | .dbf | `foreign` | `foreign` | Yes |
+| Weka Attribute-Relation File Format | .arff | `foreign` | `foreign` | Yes |
+| Data Interchange Format | .dif | `utils` |  | Yes |
+| Fortran data | no recognized extension | `utils` |  | Yes |
+| Fixed-width format data | .fwf | `utils` | `utils` | Yes |
+| gzip comma-separated data | .csv.gz | `utils` | `utils` | Yes |
+| CSVY (CSV + YAML metadata header) | .csvy | [`csvy`](https://cran.r-project.org/package=csvy) | [`csvy`](https://cran.r-project.org/package=csvy) | No |
+| Feather R/Python interchange format | .feather | [`feather`](https://cran.r-project.org/package=feather) | [`feather`](https://cran.r-project.org/package=feather) | No |
+| Fast Storage | .fst | [`fst`](https://cran.r-project.org/package=fst) | [`fst`](https://cran.r-project.org/package=fst) | No |
+| JSON | .json | [`jsonlite`](https://cran.r-project.org/package=jsonlite) | [`jsonlite`](https://cran.r-project.org/package=jsonlite) | No |
+| Matlab | .mat | [`rmatio`](https://cran.r-project.org/package=rmatio) | [`rmatio`](https://cran.r-project.org/package=rmatio) | No |
+| OpenDocument Spreadsheet | .ods | [`readODS`](https://cran.r-project.org/package=readODS) | [`readODS`](https://cran.r-project.org/package=readODS) | No |
+| HTML Tables | .html | [`xml2`](https://cran.r-project.org/package=xml2) | [`xml2`](https://cran.r-project.org/package=xml2) | No |
+| Shallow XML documents | .xml | [`xml2`](https://cran.r-project.org/package=xml2) | [`xml2`](https://cran.r-project.org/package=xml2) | No |
+| YAML | .yml | [`yaml`](https://cran.r-project.org/package=yaml) | [`yaml`](https://cran.r-project.org/package=yaml) | No |
+| Clipboard | default is tsv | [`clipr`](https://cran.r-project.org/package=clipr) | [`clipr`](https://cran.r-project.org/package=clipr) | No |
+| [Google Sheets](https://www.google.com/sheets/about/) | as Comma-separated data |  |  |  |
 
 Additionally, any format that is not supported by **rio** but that has a known R implementation will produce an informative error message pointing to a package and import or export function. Unrecognized formats will yield a simple "Unrecognized file format" error.
 
@@ -168,7 +168,7 @@ Additionally, any format that is not supported by **rio** but that has a known R
 
 The core advantage of **rio** is that it makes assumptions that the user is probably willing to make. Eight of these are important:
 
- 1. **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By taking away the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Other packages do this as well, but **rio** aims to be more complete and more consistent than each:
+ 1. **rio** uses the file extension of a file name to determine what kind of file it is. This is the same logic used by Windows OS, for example, in determining what application is associated with a given file type. By removing the need to manually match a file type (which a beginner may not recognize) to a particular import or export function, **rio** allows almost all common data formats to be read with the same function. Other packages do this as well, but **rio** aims to be more complete and more consistent than each:
  
    - [**reader**](https://cran.r-project.org/package=reader) handles certain text formats and R binary files
    - [**io**](https://cran.r-project.org/package=io) offers a set of custom formats
@@ -187,7 +187,7 @@ The core advantage of **rio** is that it makes assumptions that the user is prob
  
  7. **rio** imports and exports files based on an internal S3 class infrastructure. This means that other packages can contain extensions to **rio** by registering S3 methods. These methods should take the form `.import.rio_X()` and `.export.rio_X()`, where `X` is the file extension of a file type. An example is provided in the [rio.db package](https://github.com/leeper/rio.db).
  
- 8. **rio** wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. It uses [**haven**](https://cran.r-project.org/package=haven) for reading and writing SAS, Stata, and SPSS files, [the `fread` function from **data.table**](https://cran.r-project.org/package=data.table) for delimited formats, smarter and faster fixed-width file import and export routines, and [**readxl**](https://cran.r-project.org/package=readxl) for reading from Excel workbooks.
+ 8. **rio** wraps a variety of faster, more stream-lined I/O packages than those provided by base R or the **foreign** package. It uses [**data.table**](https://cran.r-project.org/package=data.table) for delimited formats, [**haven**](https://cran.r-project.org/package=haven) for SAS, Stata, and SPSS files, smarter and faster fixed-width file import and export routines, and [**readxl**](https://cran.r-project.org/package=readxl) and [**openxlsx**](https://cran.r-project.org/package=openxlsx) for reading and writing Excel workbooks.
 
 ## Package Installation
 

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -29,29 +29,29 @@ The output file can be to a compressed directory, simply by adding an appropriat
 \code{export} supports many file formats. See the documentation for the underlying export functions for optional arguments that can be passed via \code{...}
 
 \itemize{
-    \item Tab-separated data (.tsv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
     \item Comma-separated data (.csv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
-    \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
-    \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (\#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
     \item Pipe-separated data (.psv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{sep = '|'} and \code{row.names = FALSE}.
-    \item Feather R/Python interchange format (.feather), using \code{feather::write_feather}
-    \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
-    \item Fixed-width format data (.fwf), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}, \code{quote = FALSE}, and \code{col.names = FALSE}
-    \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
-    \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
-    \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
-    \item YAML (.yml), using \code{\link[yaml]{as.yaml}}
-    \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-    \item SPSS (.sav), using \code{\link[haven]{write_sav}}
+    \item Tab-separated data (.tsv), using \code{\link[data.table]{fwrite}} or, if \code{fwrite = TRUE}, \code{\link[utils]{write.table}} with \code{row.names = FALSE}.
     \item SAS (.sas7bdat), using \code{\link[haven]{write_sas}}.
+    \item SPSS (.sav), using \code{\link[haven]{write_sav}}
+    \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
+    \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
+    \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'}
+    \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
+    \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
     \item "XBASE" database files (.dbf), using \code{\link[foreign]{write.dbf}}
     \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{write.arff}}
-    \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'}
+    \item Fixed-width format data (.fwf), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}, \code{quote = FALSE}, and \code{col.names = FALSE}
+    \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
+    \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (\#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
+    \item Feather R/Python interchange format (.feather), using \code{feather::write_feather}
+    \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
+    \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
     \item Matlab (.mat), using \code{\link[rmatio]{write.mat}}
-    \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{write_ods}}. (Currently only single-sheet exports are supported.)
-    \item XML (.xml), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple XML tree and \code{\link[xml2]{write_xml}} to write to disk.
     \item HTML (.html), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple HTML table and \code{\link[xml2]{write_xml}} to write to disk.
+    \item XML (.xml), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple XML tree and \code{\link[xml2]{write_xml}} to write to disk.
+    \item YAML (.yml), using \code{\link[yaml]{as.yaml}}
     \item Clipboard export (on Windows and Mac OS), using \code{\link[utils]{write.table}} with \code{row.names = FALSE}
 }
 }

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -29,36 +29,37 @@ This function imports a data frame or matrix from a data file with the file form
 \code{import} supports the following file formats:
 
 \itemize{
-    \item Tab-separated data (.tsv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
     \item Comma-separated data (.csv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+    \item Pipe-separated data (.psv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{sep = '|'}, \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+    \item Tab-separated data (.tsv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
+    \item SAS (.sas7bdat), using \code{\link[haven]{read_sas}}.
+    \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
+    \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
+    \item SAS XPORT (.xpt), using \code{\link[foreign]{read.xport}}.
+    \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
+    \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. If \code{readxl = FALSE}, \code{\link[openxlsx]{read.xlsx}} can be used. Use \code{which} to specify a sheet number.
+    \item R syntax object (.R), using \code{\link[base]{dget}}
+    \item Saved R objects (.RData,.rda), using \code{\link[base]{load}} for single-object .Rdata files. Use \code{which} to specify an object name for multi-object .Rdata files.
+    \item Serialized R objects (.rds), using \code{\link[base]{readRDS}}
+    \item Epiinfo (.rec), using \code{\link[foreign]{read.epiinfo}}
+    \item Minitab (.mtp), using \code{\link[foreign]{read.mtp}}
+    \item Systat (.syd), using \code{\link[foreign]{read.systat}}
+    \item "XBASE" database files (.dbf), using \code{\link[foreign]{read.dbf}}
+    \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{read.arff}}
+    \item Data Interchange Format (.dif), using \code{\link[utils]{read.DIF}}
+    \item Fortran data (no recognized extension), using \code{\link[utils]{read.fortran}}
+    \item Fixed-width format data (.fwf), using a faster version of \code{\link[utils]{read.fwf}} that requires a \code{widths} argument and by default in rio has \code{stringsAsFactors = FALSE}. If \code{readr = TRUE}, import will be performed using \code{\link[readr]{read_fwf}}, where \code{widths} should be: \code{NULL}, a vector of column widths, or the output of \code{\link[readr]{fwf_empty}}, \code{\link[readr]{fwf_widths}}, or \code{\link[readr]{fwf_positions}}.
     \item gzip comma-separated data (.csv.gz), using \code{\link[utils]{read.table}} with \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{read_csvy}}.
     \item Feather R/Python interchange format (.feather), using \code{feather::read_feather}
     \item Fast storage (.fst), using \code{\link[fst]{read.fst}}
-    \item Pipe-separated data (.psv), using \code{\link[data.table]{fread}} or, if \code{fread = FALSE}, \code{\link[utils]{read.table}} with \code{sep = '|'}, \code{row.names = FALSE} and \code{stringsAsFactors = FALSE}
-    \item Fixed-width format data (.fwf), using a faster version of \code{\link[utils]{read.fwf}} that requires a \code{widths} argument and by default in rio has \code{stringsAsFactors = FALSE}. If \code{readr = TRUE}, import will be performed using \code{\link[readr]{read_fwf}}, where \code{widths} should be: \code{NULL}, a vector of column widths, or the output of \code{\link[readr]{fwf_empty}}, \code{\link[readr]{fwf_widths}}, or \code{\link[readr]{fwf_positions}}.
-    \item Serialized R objects (.rds), using \code{\link[base]{readRDS}}
-    \item Saved R objects (.RData,.rda), using \code{\link[base]{load}} for single-object .Rdata files. Use \code{which} to specify an object name for multi-object .Rdata files.
     \item JSON (.json), using \code{\link[jsonlite]{fromJSON}}
-    \item YAML (.yml), using \code{\link[yaml]{yaml.load}}
-    \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
-    \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
-    \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
-    \item "XBASE" database files (.dbf), using \code{\link[foreign]{read.dbf}}
-    \item Weka Attribute-Relation File Format (.arff), using \code{\link[foreign]{read.arff}}
-    \item R syntax object (.R), using \code{\link[base]{dget}}
     \item Matlab (.mat), using \code{\link[rmatio]{read.mat}}
-    \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. If \code{readxl = FALSE}, \code{\link[openxlsx]{read.xlsx}} can be used. Use \code{which} to specify a sheet number.
-    \item SAS (.sas7bdat) and SAS XPORT (.xpt), using \code{\link[haven]{read_sas}} and \code{\link[foreign]{read.xport}}.
-    \item Minitab (.mtp), using \code{\link[foreign]{read.mtp}}
-    \item Epiinfo (.rec), using \code{\link[foreign]{read.epiinfo}}
-    \item Systat (.syd), using \code{\link[foreign]{read.systat}}
-    \item Data Interchange Format (.dif), using \code{\link[utils]{read.DIF}}
     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{read_ods}}.  Use \code{which} to specify a sheet number.
-    \item Shallow XML documents (.xml), using \code{\link[xml2]{read_xml}}. The data structure will only be read correctly if the XML file can be converted to a list via \code{\link[xml2]{as_list}}.
     \item Single-table HTML documents (.html), using \code{\link[xml2]{read_html}}. The data structure will only be read correctly if the HTML file can be converted to a list via \code{\link[xml2]{as_list}}.
+    \item Shallow XML documents (.xml), using \code{\link[xml2]{read_xml}}. The data structure will only be read correctly if the XML file can be converted to a list via \code{\link[xml2]{as_list}}.
+    \item YAML (.yml), using \code{\link[yaml]{yaml.load}}
     \item Clipboard import (on Windows and Mac OS), using \code{\link[utils]{read.table}} with \code{row.names = FALSE}
-    \item Fortran data (no recognized extension), using \code{\link[utils]{read.fortran}}
     \item Google Sheets, as Comma-separated data (.csv)
 }
 


### PR DESCRIPTION
This pull requests adds additional details to the supported formats list, and standardizes the order in which formats are presented across documentation. Specifically, it:

- Adds the package name and URL for both import and export
- Identifies which packages are installed by default, and
- Consistently order formats lists by package

If you think (a) this is helpful, and (b) #150 makes sense, I can add that here and update the table accordingly.