### PR TITLE
Change appveyor build order

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,11 @@ environment:
     CRAN: http://cran.rstudio.com
 
   - R_VERSION: devel
-    GCC_PATH: mingw_32
-
-  - R_VERSION: devel
     R_ARCH: x64
     GCC_PATH: mingw_64
+
+  - R_VERSION: devel
+    GCC_PATH: mingw_32
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,19 +14,19 @@ environment:
     USE_RTOOLS: true
 
   matrix:
-  - R_VERSION: devel
-    GCC_PATH: mingw_32
-
-  - R_VERSION: devel
-    R_ARCH: x64
-    GCC_PATH: mingw_64
-
   - R_VERSION: release
     R_ARCH: x64
 
   - R_VERSION: oldrel
     RTOOLS_VERSION: 33
     CRAN: http://cran.rstudio.com
+
+  - R_VERSION: devel
+    GCC_PATH: mingw_32
+
+  - R_VERSION: devel
+    R_ARCH: x64
+    GCC_PATH: mingw_64
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Prioritise the CI build `R_VERSION`s according to **release** > **oldrel** > **devel**

Potential workaround for the time being... If errors with`r-devel` occur, appveyor will still test and report on **release** and **oldrel** first