### PR TITLE
Fix changes due to xml2 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,8 +51,9 @@ Suggests:
     readODS (>= 1.6.4),
     readr,
     rmatio,
-    xml2 (>= 1.0.0),
+    xml2 (>= 1.2.0),
     yaml
 License: GPL-2
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1
+Remotes: hadley/xml2

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -356,7 +356,7 @@ function(file,
 #' @export
 .import.rio_xml <- function(file, which = 1, stringsAsFactors = FALSE, ...) {
     requireNamespace("xml2", quietly = TRUE)
-    x <- xml2::as_list(xml2::read_xml(unclass(file)))
+    x <- xml2::as_list(xml2::read_xml(unclass(file)))[[1L]]
     d <- do.call("rbind", c(lapply(x, unlist)))
     row.names(d) <- 1:nrow(d)
     d <- as.data.frame(d, stringsAsFactors = stringsAsFactors)


### PR DESCRIPTION
The upcoming 1.2.0 release of xml2 fixes a bug in as_list.xml_document
that cause the root node to be missing from the returned list. This
fix unfortunately broke rio, which is fixed by the following changes.

Once xml2 1.2.0 has been release to CRAN (should be the next few days or weeks) you can remove the `Remotes:` line and submit an updated rio version to CRAN.
  
Sorry for the breakage and your understanding!