### PR TITLE
Remove overwrite option from export() docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co")
              person("Andrew", "MacDonald", role = "ctb"),
              person("Ista", "Zahn", role = "ctb"),
              person("Stanislaus", "Stadlmann", role = "ctb"),
-             person("Ruaridh", "Williamson", role = "ctb", email = "ruaridh.williamson@gmail.com"))
+             person("Ruaridh", "Williamson", role = "ctb", email = "ruaridh.williamson@gmail.com"),
+             person("Patrick", "Kennedy", role = "ctb"))
 Description: Streamlined data import and export by making assumptions that
     the user is probably willing to make: 'import()' and 'export()' determine
     the data structure from the file extension, reasonable defaults are used for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rio 0.5.11
+
+ * Updated documentation to reflect recent changes to the xlsx `export()` method. (#156)
+
 # rio 0.5.10
 
  * Removed some csvy-related tests, which were failing on CRAN.

--- a/R/export.R
+++ b/R/export.R
@@ -7,7 +7,7 @@
 #' @param \dots Additional arguments for the underlying export functions. See examples.
 #' @return The name of the output file as a character string (invisibly).
 #' @details This function exports a data frame or matrix into a file with file format based on the file extension (or the manually specified format, if \code{format} is specified).
-#'
+#' 
 #' The output file can be to a compressed directory, simply by adding an appropriate additional extensiont to the \code{file} argument, such as: \dQuote{mtcars.csv.tar}, \dQuote{mtcars.csv.zip}, or \dQuote{mtcars.csv.gz}.
 #'
 #' \code{export} supports many file formats. See the documentation for the underlying export functions for optional arguments that can be passed via \code{...}
@@ -20,7 +20,7 @@
 #'     \item SAS XPORT (.xpt), using \code{\link[haven]{write_xpt}}.
 #'     \item SPSS (.sav), using \code{\link[haven]{write_sav}}
 #'     \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-#'     \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
+#'     \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Existing workbooks are overwritten unless \code{which} is specified, in which case only the specified sheet (if it exists) is overwritten. If the file exists but the \code{which} sheet does not, data are added as a new sheet to the existing workbook. \code{x} can also be a list of data frames; the list entry names are used as sheet names.
 #'     \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'})
 #'     \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
 #'     \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
@@ -83,8 +83,8 @@
 #'   ## export a list of data frames as worksheets
 #'   export(list(a = mtcars, b = iris), "multisheet.xlsx")
 #' 
-#'   ## export, adding sheet to an existing workbook
-#'   export(iris, "mtcars.xlsx", which = "iris", overwrite = FALSE)
+#'   ## export, adding a new sheet to an existing workbook
+#'   export(iris, "mtcars.xlsx", which = "iris")
 #' }
 #'
 #' # write data to a zip-compressed CSV

--- a/docs/PULL_REQUEST_TEMPLATE.html
+++ b/docs/PULL_REQUEST_TEMPLATE.html
@@ -96,7 +96,7 @@
 <li>[ ] if suggesting code changes or improvements, <a href="https://github.com/leeper/rio/issues/new">open an issue</a> first</li>
 <li>[ ] for all but trivial changes (e.g., typo fixes), add your name to <a href="https://github.com/leeper/rio/blob/master/DESCRIPTION">DESCRIPTION</a>
 </li>
-<li>[ ] for all but trivial changes (e.g., typo fixes), documentation your change in <a href="https://github.com/leeper/rio/blob/master/NEWS.html">NEWS.md</a> with a parenthetical reference to the issue number being addressed</li>
+<li>[ ] for all but trivial changes (e.g., typo fixes), document your change in <a href="https://github.com/leeper/rio/blob/master/NEWS.html">NEWS.md</a> with a parenthetical reference to the issue number being addressed</li>
 <li>[ ] if changing documentation, edit files in <code>/R</code> not <code>/man</code> and run <code><a href="http://www.rdocumentation.org/packages/devtools/topics/document">devtools::document()</a></code> to update documentation</li>
 <li>[ ] add code or new test files to <a href="https://github.com/leeper/rio/tree/master/tests/testthat"><code>/tests</code></a> for any new functionality or bug fix</li>
 <li>[ ] make sure <code>R CMD check</code> runs without error before submitting the PR</li>

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -36,7 +36,7 @@ The output file can be to a compressed directory, simply by adding an appropriat
     \item SAS XPORT (.xpt), using \code{\link[haven]{write_xpt}}.
     \item SPSS (.sav), using \code{\link[haven]{write_sav}}
     \item Stata (.dta), using \code{\link[haven]{write_dta}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-    \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Use \code{which} to specify a sheet name and \code{overwrite} to decide whether to overwrite an existing file or worksheet (the default) or add the data as a new worksheet (with \code{overwrite = FALSE}). \code{x} can also be a list of data frames; the list entry names are used as sheet names.
+    \item Excel (.xlsx), using \code{\link[openxlsx]{write.xlsx}}. Existing workbooks are overwritten unless \code{which} is specified, in which case only the specified sheet (if it exists) is overwritten. If the file exists but the \code{which} sheet does not, data are added as a new sheet to the existing workbook. \code{x} can also be a list of data frames; the list entry names are used as sheet names.
     \item R syntax object (.R), using \code{\link[base]{dput}} (by default) or \code{\link[base]{dump}} (if \code{format = 'dump'})
     \item Saved R objects (.RData,.rda), using \code{\link[base]{save}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
     \item Serialized R objects (.rds), using \code{\link[base]{saveRDS}}
@@ -99,8 +99,8 @@ source("data.R", echo = TRUE)
   ## export a list of data frames as worksheets
   export(list(a = mtcars, b = iris), "multisheet.xlsx")
 
-  ## export, adding sheet to an existing workbook
-  export(iris, "mtcars.xlsx", which = "iris", overwrite = FALSE)
+  ## export, adding a new sheet to an existing workbook
+  export(iris, "mtcars.xlsx", which = "iris")
 }
 
 # write data to a zip-compressed CSV


### PR DESCRIPTION
This PR updates the export() documentation to remove the now obsolete overwrite option from the Details and Examples sections.

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

