### PR TITLE
Adjust JSON handling to be like RDS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,9 @@ Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co")
              person("Ruaridh", "Williamson", role = "ctb", email = "ruaridh.williamson@gmail.com"),
              person("Patrick", "Kennedy", role = "ctb"),
              person("Ryan", "Price", email = "ryapric@gmail.com", role = "ctb"),
-             person("Trevor L", "Davis", email = "trevor.l.davis@gmail.com", role = "ctb"))
+             person("Trevor L", "Davis", email = "trevor.l.davis@gmail.com", role = "ctb"),
+             person("Nathan", "Day", email = "nathancday@gmail.com", role = "ctb")
+             )
 Description: Streamlined data import and export by making assumptions that
     the user is probably willing to make: 'import()' and 'export()' determine
     the data structure from the file extension, reasonable defaults are used for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rio 0.5.17.99
+
+ * Adjust `import()`/`export()` for JSON file formats to allow non-data frame objects. Behavior modeled after RDS format. (#199 h/t Nathan Day)
+
 # rio 0.5.17
 
  * Fix `the condition has length > 1 and only the first element will be used` warning in `gather_attributes()`. (#196, h/t Ruben Arslan)

--- a/R/export.R
+++ b/R/export.R
@@ -1,7 +1,7 @@
 #' @rdname export
 #' @title Export
 #' @description Write data.frame to a file
-#' @param x A data frame or matrix to be written into a file. (An exception to this is that \code{x} can be a list of data frames if the output file format is an Excel .xlsx workbook, .Rdata file, or HTML file. See examples.)
+#' @param x A data frame or matrix to be written into a file. Exceptions to this rule is that \code{x} can be a list of data frames if the output file format is an Excel .xlsx workbook, .Rdata file, or HTML file. Or a variety of R objects if the output file format is RDS or JSON. See examples.)
 #' @param file A character string naming a file. Must specify \code{file} and/or \code{format}.
 #' @param format An optional character string containing the file format, which can be used to override the format inferred from \code{file} or, in lieu of specifying \code{file}, a file with the symbol name of \code{x} and the specified file extension will be created. Must specify \code{file} and/or \code{format}. Shortcuts include: \dQuote{,} (for comma-separated values), \dQuote{;} (for semicolon-separated values), \dQuote{|} (for pipe-separated values), and \dQuote{dump} for \code{\link[base]{dump}}.
 #' @param \dots Additional arguments for the underlying export functions. See examples.
@@ -31,7 +31,7 @@
 #'     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
 #'     \item Feather R/Python interchange format (.feather), using \code{\link[feather]{write_feather}}
 #'     \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
-#'     \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
+#'     \item JSON (.json), using \code{\link[jsonlite]{toJSON}}. In this case, \code{x} can be a variety of R objects, based on class mapping conventions in this paper: \href{https://arxiv.org/abs/1403.2805}{https://arxiv.org/abs/1403.2805}. 
 #'     \item Matlab (.mat), using \code{\link[rmatio]{write.mat}}
 #'     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{write_ods}}. (Currently only single-sheet exports are supported.)
 #'     \item HTML (.html), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple HTML table and \code{\link[xml2]{write_xml}} to write to disk.
@@ -64,8 +64,9 @@
 #' export(list(mtcars = mtcars, iris = iris), "mtcars.rdata")
 #' export(c("mtcars", "iris"), "mtcars.rdata")
 #'
-#' # export to JSON
-#' export(mtcars, "mtcars.json")
+#' # export to non-data frame R object to RDS or JSON
+#' export(mtcars$cyl, "mtcars_cyl.rds")
+#' export(list(iris, mtcars), "list.json")
 #'
 #' # pass arguments to underlying export function
 #' export(mtcars, "mtcars.csv", col.names = FALSE)
@@ -93,10 +94,11 @@
 #' # cleanup
 #' unlink("mtcars.csv")
 #' unlink("mtcars.dta")
-#' unlink("mtcars.json")
+#' unlink("mtcars_cyl.rds")
 #' unlink("mtcars.rdata")
 #' unlink("data.R")
 #' unlink("mtcars.csv.zip")
+#' unlink("list.json")
 #' @seealso \code{\link{.export}}, \code{\link{characterize}}, \code{\link{import}}, \code{\link{convert}}
 #' @importFrom haven labelled
 #' @export
@@ -130,7 +132,7 @@ export <- function(x, file, format, ...) {
 
     data_name <- as.character(substitute(x))
     if (!is.data.frame(x) & !is.matrix(x)) {
-        if (!fmt %in% c("xlsx", "html", "rdata", "rds")) {
+        if (!fmt %in% c("xlsx", "html", "rdata", "rds", "json")) {
             stop("'x' is not a data.frame or matrix")
         }
     } else if (is.matrix(x)) {

--- a/R/import.R
+++ b/R/import.R
@@ -1,6 +1,6 @@
 #' @rdname import
 #' @title Import
-#' @description Read in a data.frame from a file
+#' @description Read in a data.frame from a file. Exceptions to this rule, are Rdata, RDS and JSON input file formats, which return the originally saved object without changing it's class.
 #' @param file A character string naming a file, URL, or single-file .zip or .tar archive.
 #' @param format An optional character string code of file format, which can be used to override the format inferred from \code{file}. Shortcuts include: \dQuote{,} (for comma-separated values), \dQuote{;} (for semicolon-separated values), and \dQuote{|} (for pipe-separated values).
 #' @template setclass
@@ -75,11 +75,17 @@
 #'
 #' # set class for the response data.frame as "tbl_df" (from dplyr)
 #' stopifnot(inherits(import("iris1.csv", setclass = "tbl_df"), "tbl_df"))
+#' 
+#' # non-data frame formats supported for RDS, Rdata, and JSON
+#' export(list(mtcars, iris), "list.rds")
+#' li <- import("list.rds")
+#' identical(names(mtcars), names(li[[1]]))
 #'
 #' # cleanup
 #' unlink("iris.tsv")
 #' unlink("iris1.csv")
 #' unlink("iris2.csv")
+#' unlist("list.rds")
 #'
 #' @seealso \code{\link{import_list}}, \code{\link{.import}}, \code{\link{characterize}}, \code{\link{gather_attrs}}, \code{\link{export}}, \code{\link{convert}}
 #' @importFrom tools file_ext file_path_sans_ext
@@ -130,7 +136,7 @@ import <- function(file, format, setclass, which, ...) {
     }
     
     # if R serialized object, just return it without setting object class
-    if (inherits(file, "rio_rdata") || inherits(file, "rio_rds")) {
+    if (inherits(file, c("rio_rdata", "rio_rds", "rio_json"))) {
         return(x)
     }
     # otherwise, make sure it's a data frame (or requested class)

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -7,7 +7,7 @@
 export(x, file, format, ...)
 }
 \arguments{
-\item{x}{A data frame or matrix to be written into a file. (An exception to this is that \code{x} can be a list of data frames if the output file format is an Excel .xlsx workbook, .Rdata file, or HTML file. See examples.)}
+\item{x}{A data frame or matrix to be written into a file. Exceptions to this rule is that \code{x} can be a list of data frames if the output file format is an Excel .xlsx workbook, .Rdata file, or HTML file. Or a variety of R objects if the output file format is RDS or JSON. See examples.)}
 
 \item{file}{A character string naming a file. Must specify \code{file} and/or \code{format}.}
 
@@ -47,7 +47,7 @@ The output file can be to a compressed directory, simply by adding an appropriat
     \item \href{https://github.com/csvy}{CSVY} (CSV with a YAML metadata header) using \code{\link[csvy]{write_csvy}}. The YAML header lines are preceded by R comment symbols (#) by default; this can be turned off by passing a \code{comment_header = FALSE} argument to \code{export}. Setting \code{fwrite = TRUE} (the default) will rely on \code{\link[data.table]{fwrite}} for much faster export.
     \item Feather R/Python interchange format (.feather), using \code{\link[feather]{write_feather}}
     \item Fast storage (.fst), using \code{\link[fst]{write.fst}}
-    \item JSON (.json), using \code{\link[jsonlite]{toJSON}}
+    \item JSON (.json), using \code{\link[jsonlite]{toJSON}}. In this case, \code{x} can be a variety of R objects, based on class mapping conventions in this paper: \href{https://arxiv.org/abs/1403.2805}{https://arxiv.org/abs/1403.2805}. 
     \item Matlab (.mat), using \code{\link[rmatio]{write.mat}}
     \item OpenDocument Spreadsheet (.ods), using \code{\link[readODS]{write_ods}}. (Currently only single-sheet exports are supported.)
     \item HTML (.html), using a custom method based on \code{\link[xml2]{xml_add_child}} to create a simple HTML table and \code{\link[xml2]{write_xml}} to write to disk.
@@ -80,8 +80,9 @@ export(mtcars, file = "mtcars.txt", format = "csv")
 export(list(mtcars = mtcars, iris = iris), "mtcars.rdata")
 export(c("mtcars", "iris"), "mtcars.rdata")
 
-# export to JSON
-export(mtcars, "mtcars.json")
+# export to non-data frame R object to RDS or JSON
+export(mtcars$cyl, "mtcars_cyl.rds")
+export(list(iris, mtcars), "list.json")
 
 # pass arguments to underlying export function
 export(mtcars, "mtcars.csv", col.names = FALSE)
@@ -109,10 +110,11 @@ export(mtcars, "mtcars.csv.zip")
 # cleanup
 unlink("mtcars.csv")
 unlink("mtcars.dta")
-unlink("mtcars.json")
+unlink("mtcars_cyl.rds")
 unlink("mtcars.rdata")
 unlink("data.R")
 unlink("mtcars.csv.zip")
+unlink("list.json")
 }
 \seealso{
 \code{\link{.export}}, \code{\link{characterize}}, \code{\link{import}}, \code{\link{convert}}

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -21,7 +21,7 @@ import(file, format, setclass, which, ...)
 A data frame. If \code{setclass} is used, this data frame may have additional class attribute values, such as \dQuote{tibble} or \dQuote{data.table}.
 }
 \description{
-Read in a data.frame from a file
+Read in a data.frame from a file. Exceptions to this rule, are Rdata, RDS and JSON input file formats, which return the originally saved object without changing it's class.
 }
 \details{
 This function imports a data frame or matrix from a data file with the file format based on the file extension (or the manually specified format, if \code{format} is specified).
@@ -95,10 +95,16 @@ identical(names(iris), names(iris2))
 # set class for the response data.frame as "tbl_df" (from dplyr)
 stopifnot(inherits(import("iris1.csv", setclass = "tbl_df"), "tbl_df"))
 
+# non-data frame formats supported for RDS, Rdata, and JSON
+export(list(mtcars, iris), "list.rds")
+li <- import("list.rds")
+identical(names(mtcars), names(li[[1]]))
+
 # cleanup
 unlink("iris.tsv")
 unlink("iris1.csv")
 unlink("iris2.csv")
+unlist("list.rds")
 
 }
 \seealso{

--- a/tests/testthat/test_format_json.R
+++ b/tests/testthat/test_format_json.R
@@ -9,4 +9,11 @@ test_that("Import from JSON", {
     expect_true(is.data.frame(import("iris.json")))
 })
 
+test_that("Export to JSON (non-data frame)", {
+    expect_true(export(list(1:10, letters), "list.json") %in% dir())
+    expect_true(inherits(import("list.json"), "list"))
+    expect_true(length(import("list.json")) == 2L)
+})
+
 unlink("iris.json")
+unlink("list.json")


### PR DESCRIPTION
After digging into the code I pivoted to adjusting handling of JSON file formats in `import()` and `export()` instead of in `import_list()`. My thought process was that because the underlying `jsonlite` functions don't have a which/itemizer to specify a sub unit , like XLS sheets, nor are the objects saved in itemized way like `Rdata`, the `import_list()` function didn't really fit. But since `toJSON()` and `fromJSON()` already handle a variety of R object classes I figured the current pattern for `RDS` objects was most similar to the concept of `jsonlite`. I realize this is a detour from the original issue I raised about import JSON lists #199 but it seems to fit with issue #183. Thoughts?
