### PR TITLE
Improve messages when tests are skipped due to missing packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,11 @@ Authors@R: c(person("Jason", "Becker", role = "ctb", email = "jason@jbecker.co")
              person("Patrick", "Kennedy", role = "ctb"),
              person("Ryan", "Price", email = "ryapric@gmail.com", role = "ctb"),
              person("Trevor L", "Davis", email = "trevor.l.davis@gmail.com", role = "ctb"),
-             person("Nathan", "Day", email = "nathancday@gmail.com", role = "ctb")
+             person("Nathan", "Day", email = "nathancday@gmail.com", role = "ctb"),
+             person("Bill", "Denney",
+                    email="wdenney@humanpredictions.com",
+                    role="ctb",
+                    comment=c(ORCID="0000-0002-5759-428X"))
              )
 Description: Streamlined data import and export by making assumptions that
     the user is probably willing to make: 'import()' and 'export()' determine

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
  * Fix behavior of `export()` to plain text files when `append = TRUE` (#201, h/t Julián Urbano)
  * `import_list()` now preserve names of Excel sheets, etc. when the 'which' argument is specified. (#162, h/t Danny Parsons)
  * Modify message and errors when working with unrecognized file formats. (#195, h/t Trevor Davis)
+ * Ensure that tests only run if the corresponding package is installed.  (h/t Bill Denney)
 
 # rio 0.5.18
 

--- a/tests/testthat/test_format_csvy.R
+++ b/tests/testthat/test_format_csvy.R
@@ -4,10 +4,12 @@ require("datasets")
 tmp <- tempfile(fileext = ".csvy")
 
 test_that("Export to CSVY", {
+    skip_if_not_installed(pkg="csvy")
     suppressWarnings(expect_true(file.exists(export(iris, tmp))))
 })
 
 test_that("Import from CSVY", {
+    skip_if_not_installed(pkg="csvy")
     suppressWarnings(d <- import(tmp))
     expect_true(inherits(d, "data.frame"))
 })

--- a/tests/testthat/test_format_eviews.R
+++ b/tests/testthat/test_format_eviews.R
@@ -1,7 +1,6 @@
 context("EViews import")
 
-if (requireNamespace("hexView")) {
-    test_that("Import from EViews", {
-        expect_true(is.data.frame(suppressWarnings(import(hexView::hexViewFile("data4-1.wf1")))))
-    })
-}
+test_that("Import from EViews", {
+    skip_if_not_installed(pkg="hexView")
+    expect_true(is.data.frame(suppressWarnings(import(hexView::hexViewFile("data4-1.wf1")))))
+})

--- a/tests/testthat/test_format_feather.R
+++ b/tests/testthat/test_format_feather.R
@@ -1,13 +1,13 @@
 context("feather imports/exports")
 require("datasets")
 
-if (requireNamespace("feather")) {
-    test_that("Export to feather", {
-        expect_true(export(iris, "iris.feather") %in% dir())
-    })
+test_that("Export to feather", {
+    skip_if_not_installed(pkg="feather")
+    expect_true(export(iris, "iris.feather") %in% dir())
+})
 
-    test_that("Import from feather", {
-        expect_true(is.data.frame(import("iris.feather")))
-    })
-    unlink("iris.feather")
-}
+test_that("Import from feather", {
+    skip_if_not_installed(pkg="feather")
+    expect_true(is.data.frame(import("iris.feather")))
+})
+unlink("iris.feather")

--- a/tests/testthat/test_format_fst.R
+++ b/tests/testthat/test_format_fst.R
@@ -1,13 +1,13 @@
 context("fst imports/exports")
 require("datasets")
 
-if (requireNamespace("fst")) {
-    test_that("Export to fst", {
-        expect_true(export(iris, "iris.fst") %in% dir())
-    })
+test_that("Export to fst", {
+    skip_if_not_installed(pkg="fst")
+    expect_true(export(iris, "iris.fst") %in% dir())
+})
 
-    test_that("Import from fst", {
-        expect_true(is.data.frame(import("iris.fst")))
-    })
-    unlink("iris.fst")
-}
+test_that("Import from fst", {
+    skip_if_not_installed(pkg="fst")
+    expect_true(is.data.frame(import("iris.fst")))
+})
+unlink("iris.fst")

--- a/tests/testthat/test_format_matlab.R
+++ b/tests/testthat/test_format_matlab.R
@@ -1,14 +1,14 @@
 context("rmatio imports/exports")
 require("datasets")
 
-if (requireNamespace("rmatio")) {
-    test_that("Export to matlab", {
-        expect_true(export(iris, "iris.matlab") %in% dir())
-    })
+test_that("Export to matlab", {
+    skip_if_not_installed(pkg="rmatio")
+    expect_true(export(iris, "iris.matlab") %in% dir())
+})
 
-    test_that("Import from matlab", {
-        expect_true(is.data.frame(import("iris.matlab")))
-        expect_true(identical(dim(import("iris.matlab")), dim(iris)))
-    })
-    unlink("iris.matlab")
-}
+test_that("Import from matlab", {
+    skip_if_not_installed(pkg="rmatio")
+    expect_true(is.data.frame(import("iris.matlab")))
+    expect_true(identical(dim(import("iris.matlab")), dim(iris)))
+})
+unlink("iris.matlab")

--- a/tests/testthat/test_format_ods.R
+++ b/tests/testthat/test_format_ods.R
@@ -2,6 +2,7 @@ context("ODS imports/exports")
 require("datasets")
 
 test_that("Import from ODS", {
+    skip_if_not_installed(pkg="readODS")
     ods <- import(system.file("examples", "mtcars.ods", package = "rio"))
     expect_true(is.data.frame(ods), label = "ODS import returns data.frame")
     expect_true(identical(names(mtcars), names(ods)), label = "ODS import returns correct names")
@@ -9,6 +10,7 @@ test_that("Import from ODS", {
 })
 
 test_that("Export to ODS", {
+    skip_if_not_installed(pkg="readODS")
     expect_true(export(iris, "iris.ods") %in% dir())
 })
 

--- a/tests/testthat/test_identical.R
+++ b/tests/testthat/test_identical.R
@@ -4,53 +4,54 @@ test_that("Data identical (text formats)", {
     expect_equivalent(import(export(mtcars, "mtcars.txt")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.csv")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.tsv")), mtcars)
-    unlink("mtcars.txt")
-    unlink("mtcars.csv")
-    unlink("mtcars.tsv")
 })
+unlink("mtcars.txt")
+unlink("mtcars.csv")
+unlink("mtcars.tsv")
 
 test_that("Data identical (R formats)", {
     expect_equivalent(import(export(mtcars, "mtcars.rds")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.R")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.RData")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.R", format = "dump")), mtcars)
-    if (requireNamespace("feather")) {
-        expect_equivalent(import(export(mtcars, "mtcars.feather")), mtcars)
-        unlink("mtcars.feather")
-    }
-    unlink("mtcars.rds")
-    unlink("mtcars.R")
-    unlink("mtcars.RData")
+})
+unlink("mtcars.rds")
+unlink("mtcars.R")
+unlink("mtcars.RData")
+test_that("Data identical (R formats), feather", {
+    skip_if_not_installed(pkg="feather")
+    expect_equivalent(import(export(mtcars, "mtcars.feather")), mtcars)
+    unlink("mtcars.feather")
 })
 
 test_that("Data identical (haven formats)", {
     expect_equivalent(import(export(mtcars, "mtcars.dta")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.sav")), mtcars)
-    unlink("mtcars.dta")
-    unlink("mtcars.sav")
 })
+unlink("mtcars.dta")
+unlink("mtcars.sav")
 
 test_that("Data identical (Excel formats)", {
     expect_equivalent(import(export(mtcars, "mtcars.xlsx")), mtcars)
-    unlink("mtcars.xlsx")
 })
+unlink("mtcars.xlsx")
 
 test_that("Data identical (other formats)", {
     expect_equivalent(import(export(mtcars, "mtcars.dbf")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.json")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.arff")), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.xml")), mtcars)
-    unlink("mtcars.dbf")
-    unlink("mtcars.json")
-    unlink("mtcars.arff")
-    unlink("mtcars.xml")
 })
+unlink("mtcars.dbf")
+unlink("mtcars.json")
+unlink("mtcars.arff")
+unlink("mtcars.xml")
 
 test_that("Data identical (optional arguments)", {
     #expect_equivalent(import(export(mtcars, "mtcars.csv", format = "csv2"), format = "csv2"), mtcars)
     expect_equivalent(import(export(mtcars, "mtcars.csv"), nrows = 4), mtcars[1:4,])
     expect_equivalent(import(export(mtcars, "mtcars.csv", format = "tsv"), format = "tsv"), mtcars)
     expect_true(all.equal(import(export(mtcars, "mtcars", format = "csv"), format = "csv"), mtcars, check.attributes = FALSE))
-    unlink("mtcars.csv")
-    unlink("mtcars")
 })
+unlink("mtcars.csv")
+unlink("mtcars")

--- a/tests/testthat/test_remote.R
+++ b/tests/testthat/test_remote.R
@@ -21,6 +21,7 @@ test_that("Import Remote GitHub File", {
 })
 
 test_that("Import Remote File from Shortened URL", {
+    skip_if_not_installed(pkg="csvy")
     shorturl <- "https://goo.gl/KPFiaK"
     expect_true(inherits(import(shorturl), "data.frame"), label = "Import remote file")
 })


### PR DESCRIPTION
While working on #211, I got several errors about libraries missing.  I updated the tests so that the missing libraries are now indicated as skipped tests across the board rather than having them show up as errors in some cases.  Also, skipped libraries were sometimes not shown since they were inside `if (requireNamespace())` calls where it seems like it is preferable to show that the test is skipped rather than not showing the test at all.