### PR TITLE
Remove duplication of SAS XPORT in `import()` documentation

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -19,7 +19,6 @@
 #'     \item SAS XPORT (.xpt), using \code{\link[haven]{read_xpt}} or, if \code{haven = FALSE}, \code{\link[foreign]{read.xport}}.
 #'     \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
 #'     \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
-#'     \item SAS XPORT (.xpt), using \code{\link[foreign]{read.xport}}.
 #'     \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
 #'     \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. Use \code{which} to specify a sheet number. For .xlsx files, it is possible to set \code{readxl = FALSE}, so that \code{\link[openxlsx]{read.xlsx}} can be used instead of readxl (the default).
 #'     \item R syntax object (.R), using \code{\link[base]{dget}}

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -36,7 +36,6 @@ This function imports a data frame or matrix from a data file with the file form
     \item SAS XPORT (.xpt), using \code{\link[haven]{read_xpt}} or, if \code{haven = FALSE}, \code{\link[foreign]{read.xport}}.
     \item SPSS (.sav), using \code{\link[haven]{read_sav}}. If \code{haven = FALSE}, \code{\link[foreign]{read.spss}} can be used.
     \item Stata (.dta), using \code{\link[haven]{read_dta}}. If \code{haven = FALSE}, \code{\link[foreign]{read.dta}} can be used.
-    \item SAS XPORT (.xpt), using \code{\link[foreign]{read.xport}}.
     \item SPSS Portable Files (.por), using \code{\link[haven]{read_por}}.
     \item Excel (.xls and .xlsx), using \code{\link[readxl]{read_excel}}. Use \code{which} to specify a sheet number. For .xlsx files, it is possible to set \code{readxl = FALSE}, so that \code{\link[openxlsx]{read.xlsx}} can be used instead of readxl (the default).
     \item R syntax object (.R), using \code{\link[base]{dget}}


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION]

Change is trivial.

SAS XPORT was duplicated in the list of import functions.  I removed the duplication.