### PR TITLE
Added dynamic argument checking for 'readODS:read_ods()'

### DIFF
--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -372,12 +372,12 @@ function(file,
         a[["path"]] <- NULL
     }
     if (length(unused)>0) {
-        warning("The following arguments were ignored for read_ods:",
-                "\n", paste(unused, collapse = ', '))
+        warning("The following arguments were ignored for read_ods:\n",
+                paste(unused, collapse = ', '))
     }
     a <- a[intersect(names(a), names(frml))]
-    do.call("read_ods"
-            ,c(list(path = file, sheet = which, col_names = header),a))
+    do.call("read_ods",
+            c(list(path = file, sheet = which, col_names = header),a))
 }
 
 #' @importFrom utils type.convert

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -355,7 +355,29 @@ function(file,
 #' @export
 .import.rio_ods <- function(file, which = 1, header = TRUE, ...) {
     requireNamespace("readODS")
-    readODS::read_ods(path = file, sheet = which, col_names = header, ...)
+    "read_ods" <- readODS::read_ods
+    a <- list(...)
+    if ("sheet" %in% names(a)) {
+        which <- a[["sheet"]]
+        a[["sheet"]] <- NULL
+    }
+    if ("col_names" %in% names(a)) {
+        header <- a[["col_names"]]
+        a[["col_names"]] <- NULL
+    }
+    frml <- formals(readODS::read_ods)
+    unused <- setdiff(names(a), names(frml))
+    if ("path" %in% names(a)) {
+        unused <- c(unused, 'path')
+        a[["path"]] <- NULL
+    }
+    if (length(unused)>0) {
+        warning("The following arguments were ignored for read_ods:",
+                "\n", paste(unused, collapse = ', '))
+    }
+    a <- a[intersect(names(a), names(frml))]
+    do.call("read_ods"
+            ,c(list(path = file, sheet = which, col_names = header),a))
 }
 
 #' @importFrom utils type.convert

--- a/tests/testthat/test_format_ods.R
+++ b/tests/testthat/test_format_ods.R
@@ -3,10 +3,22 @@ require("datasets")
 
 test_that("Import from ODS", {
     skip_if_not_installed(pkg="readODS")
-    ods <- import(system.file("examples", "mtcars.ods", package = "rio"))
+    expect_message(ods0 <- import(system.file("examples", "mtcars.ods",
+                                              package = "rio")),
+                   'Parsed with column specification:',
+                   label = "ODS import with default arguments works")
+    expect_warning(ods <- import(system.file("examples", "mtcars.ods"
+                                             , package = "rio"),
+                                 sheet = 1, col_names = TRUE,
+                                 path = 'ignored value',
+                                 invalid_argument = 42),
+                   "The following arguments were ignored for read_ods:\ninvalid_argument, path",
+                   label = "ODS import ignores redundant and unknown arguments with a warning")
+    expect_identical(ods0,ods, label = "ODS import ignored arguments don't affect output")
     expect_true(is.data.frame(ods), label = "ODS import returns data.frame")
     expect_true(identical(names(mtcars), names(ods)), label = "ODS import returns correct names")
     expect_true(identical(dim(mtcars), dim(ods)), label = "ODS import returns correct dimensions")
+    expect_equivalent(ods,mtcars,label = "ODS import returns correct values")
 })
 
 test_that("Export to ODS", {


### PR DESCRIPTION
Added dynamic argument checking for 'readODS:read_ods()' as proposed in #223. Also more detailed tests.

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first (#223 )
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed

Note: was I supposed to increment NEWS.md to rio 0.5.21 or add my changes to the 0.5.20 entry?

 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

Only pre-existing error, not caused by this PR
