### PR TITLE
'.import.rio_rdata()' and 'import.rio_rds()' no longer passing '...' …

### DIFF
--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -144,7 +144,10 @@ function(file,
 
 #' @export
 .import.rio_rds <- function(file, which = 1, ...) {
-    readRDS(file = file, ...)
+  if (length(list(...))>0) {
+    warning("File imported using readRDS. Arguments to '...' ignored.")
+  }
+  readRDS(file = file)
 }
 
 #' @export
@@ -155,7 +158,10 @@ function(file,
 
 #' @export
 .import.rio_rdata <- function(file, which = 1, envir = new.env(), ...) {
-    load(file = file, envir = envir, ...)
+    load(file = file, envir = envir)
+    if (length(list(...))>0) {
+      warning("File imported using load. Arguments to '...' ignored.")
+    }
     if (missing(which)) {
         if (length(ls(envir)) > 1) {
             warning("Rdata file contains multiple objects. Returning first object.")

--- a/tests/testthat/test_format_rdata.R
+++ b/tests/testthat/test_format_rdata.R
@@ -17,6 +17,11 @@ test_that("Export to Rdata", {
 test_that("Import from Rdata", {
     expect_true(is.data.frame(import("iris.Rdata")))
     expect_true(is.data.frame(import("iris.Rdata", which = 1)))
+    expect_warning(is.data.frame(import("iris.Rdata",which=1,
+                                        verbose='ignored value',
+                                        invalid_argument=42)),
+                   "File imported using load. Arguments to '...' ignored.",
+                   label="RData imports and ignores unused arguments with a warning")
 })
 
 test_that("Export to rda", {
@@ -26,6 +31,11 @@ test_that("Export to rda", {
 test_that("Import from rda", {
     expect_true(is.data.frame(import("iris.rda")))
     expect_true(is.data.frame(import("iris.rda", which = 1)))
+    expect_warning(is.data.frame(import("iris.rda", which=1,
+                                        verbose="ignored value",
+                                        invalid_argument=42)),
+                   "File imported using load. Arguments to '...' ignored.",
+                   label="rda imports and ignores unused arguments with a warning")
 })
 
 unlink("iris.Rdata")

--- a/tests/testthat/test_format_rds.R
+++ b/tests/testthat/test_format_rds.R
@@ -7,6 +7,9 @@ test_that("Export to rds", {
 
 test_that("Import from rds", {
     expect_true(is.data.frame(import("iris.rds")))
+    expect_warning(import("iris.rds", invalid_argument=42),
+                   "File imported using readRDS. Arguments to '...' ignored.",
+                   label="rda imports and ignores unused arguments with a warning")
 })
 
 test_that("Export to rds (non-data frame)", {


### PR DESCRIPTION
…to 'load()' nor to 'readRDS()' because those underlying functions cannot accept '...' arguments. Instead, the length of '...' is checked and if > 0 a warning is issued. With corresponding tests. As proposed in #223

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
Issue #223 
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
Awaiting guidance.
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
No changes
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

No failures attributable to this PR.