### PR TITLE
'.import.rio_xls()' no longer passing '...' to 'read_xls()' 

### DIFF
--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -295,17 +295,24 @@ function(file,
 #' @export
 .import.rio_xls <- function(file, which = 1, ...) {
 
-    Call <- match.call(expand.dots = TRUE)
-    if ("which" %in% names(Call)) {
-        Call$sheet <- Call$which
-        Call$which <- NULL
+    a <- list(...)
+    if ("sheet" %in% names(a)) {
+        which <- a[["sheet"]]
+        a[["sheet"]] <- NULL
     }
-
-    Call$path <- file
-    Call$file <- NULL
-    Call$readxl <- NULL
-    Call[[1L]] <- as.name("read_xls")
-    eval.parent(Call)
+    requireNamespace("readxl")
+    frml <- formals(read_xls)
+    unused <- setdiff(names(a), names(frml))
+    if ("path" %in% names(a)) {
+        unused <- c(unused, 'path')
+        a[["path"]] <- NULL
+    }
+    if (length(unused)>0) {
+        warning("The following arguments were ignored by read_xls:",
+                "\n", paste(unused, collapse=', '))
+    }
+    a <- a[intersect(names(a), names(frml))]
+    do.call("read_xls", c(list(path = file, sheet = which), a))
 }
 
 #' @importFrom readxl read_xlsx

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -300,7 +300,6 @@ function(file,
         which <- a[["sheet"]]
         a[["sheet"]] <- NULL
     }
-    requireNamespace("readxl")
     frml <- formals(read_xls)
     unused <- setdiff(names(a), names(frml))
     if ("path" %in% names(a)) {
@@ -308,8 +307,8 @@ function(file,
         a[["path"]] <- NULL
     }
     if (length(unused)>0) {
-        warning("The following arguments were ignored by read_xls:",
-                "\n", paste(unused, collapse=', '))
+        warning("The following arguments were ignored by read_xls:\n",
+                paste(unused, collapse=', '))
     }
     a <- a[intersect(names(a), names(frml))]
     do.call("read_xls", c(list(path = file, sheet = which), a))

--- a/tests/testthat/test_format_xls.R
+++ b/tests/testthat/test_format_xls.R
@@ -12,7 +12,9 @@ test_that("Import from Excel (.xlsx)", {
     expect_true(is.data.frame(import("iris.xlsx", sheet = 1)))
     expect_true(is.data.frame(import("iris.xlsx", which = 1)))
     expect_true(nrow(import("iris.xlsx", n_max = 42))==42)
-    expect_true(is.data.frame(import("iris.xlsx", nrows = 42)))
+    expect_warning(is.data.frame(import("iris.xlsx", nrows = 42)),
+                   "The following arguments were ignored when readxl = TRUE:\nnrows",
+                   label="xlsx reads the file and ignores unused arguments with warning")
 })
 
 test_that("Import from Excel (.xls)", {
@@ -22,6 +24,11 @@ test_that("Import from Excel (.xls)", {
                                                  package='rio'), sheet = 1)))
     expect_true(is.data.frame(import(system.file('examples','iris.xls',
                                                  package='rio'), which = 1)))
+    expect_warning(is.data.frame(import(system.file('examples','iris.xls',
+                                                 package='rio'), which = 1,
+                                        invalid_argument = 42)),
+                                 "The following arguments were ignored by read_xls:",
+                                 label="xls reads the file and ignores unused arguments with warning")
 })
 
 


### PR DESCRIPTION
because that function cannot accept '...' arguments. Instead, the length of '...' is checked and if > 0 a warning is issued. With corresponding tests. Also went back and changed my earlier 'read_xlsx()' test to be 'expect_warning()' instead of 'expect_true()' since by that point that's what needs testing.

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first

This addresses the final part of #223 , #224 , and item 2 in #226 

 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed

Awaiting guidance
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
No changes
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR
No new errors.
