### PR TITLE
I got Mac builds to stop failing on Travis-CI by... 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: r
-sudo: false
 cache: packages
-matrix:
+jobs:
   include:
     - os: linux
       r: oldrel
@@ -13,12 +12,6 @@ matrix:
       dist: trusty
       env: R_CODECOV=true
     - os: osx
-      osx_image: xcode8.3
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&
-    export PATH="/usr/local/opt/llvm/bin:$PATH" &&
-    export LDFLAGS="-L/usr/local/opt/llvm/lib" &&
-    export CFLAGS="-I/usr/local/opt/llvm/include"; fi
 r_packages:
 - covr
 after_success:


### PR DESCRIPTION

1. removing the xcode8.3 setting, letting the current default (and newer) version of xcode be used instead. 
2. taking the before_install script back out because now the data.table binary is again available. 

Fixes #246. Fixes #242

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

