### PR TITLE
Replace '&' with '&amp;' when exporting to HTML or XML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
       dist: trusty
       env: R_CODECOV=true
     - os: osx
-      osx_image: xcode8.3
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&
-    export PATH="/usr/local/opt/llvm/bin:$PATH" &&
-    export LDFLAGS="-L/usr/local/opt/llvm/lib" &&
-    export CFLAGS="-I/usr/local/opt/llvm/include"; fi
 r_packages:
 - covr
 after_success:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
  * Additional pointers were added to indicate how to load .doc, .docx, and .pdf files (#210, h/t Bill Denney)
  * Ensure that tests only run if the corresponding package is installed.  (h/t Bill Denney)
+ * Escape ampersands for html and xml export (#234 Alex Bokov) 
 
 # rio 0.5.19
 

--- a/R/export_methods.R
+++ b/R/export_methods.R
@@ -256,6 +256,8 @@ export_delim <- function(file, x, fwrite = TRUE, sep = "\t", row.names = FALSE,
     }
     for (i in seq_along(x)) {
         x[[i]][] <- lapply(x[[i]], as.character)
+        x[[i]][] <- lapply(x[[i]], function(v) gsub('&','&amp;',v))
+        names(x[[i]]) <- gsub('&','&amp;',names(x[[i]]))
         tab <- xml2::xml_add_child(bod, "table")
         # add header row
         invisible(xml2::xml_add_child(tab, xml2::read_xml(paste0(twrap(paste0(twrap(names(x[[i]]), "th"), collapse = ""), "tr"), "\n"))))
@@ -276,6 +278,10 @@ export_delim <- function(file, x, fwrite = TRUE, sep = "\t", row.names = FALSE,
     for (a in seq_along(att)) {
         xml2::xml_attr(xml, names(att)[a]) <- att[[a]]
     }
+    # remove illegal characters
+    row.names(x) <- gsub('&', '&amp;', row.names(x))
+    colnames(x) <- gsub('[ &]', '.', colnames(x))
+    x[] <- lapply(x, function(v) gsub('&', '&amp;', v))
     # add data
     for (i in seq_len(nrow(x))) {
         thisrow <- xml2::xml_add_child(xml, "Observation")

--- a/tests/testthat/test_format_html.R
+++ b/tests/testthat/test_format_html.R
@@ -5,6 +5,15 @@ test_that("Export to HTML", {
     expect_true(export(iris, "iris.html") %in% dir(), label = "export to html works")
 })
 
+test_that("Export to HTML with ampersands",{
+  iris$`R & D` <- paste(sample(letters,nrow(iris),rep=T),
+                        '&',
+                        sample(LETTERS,nrow(iris),rep=TRUE))
+  expect_true(export(iris, "iris2.html") %in% dir(), 
+              label = "export to html with ampersands works")
+})
+
+
 test_that("Import from HTML", {
     expect_true(is.data.frame(import("iris.html")), label = "import from single-table html works")
     f <- system.file("examples", "twotables.html", package = "rio")
@@ -12,4 +21,4 @@ test_that("Import from HTML", {
     expect_true(all(dim(import(f, which = 2)) == c(150, 5)), label = "import from two-table html works (which = 2)")
 })
 
-unlink("iris.html")
+unlink(c("iris.xml","iris2.xml"))

--- a/tests/testthat/test_format_xml.R
+++ b/tests/testthat/test_format_xml.R
@@ -2,11 +2,17 @@ context("XML imports/exports")
 require("datasets")
 
 test_that("Export to XML", {
-    expect_true(export(iris, "iris.xml") %in% dir())
+    expect_true(export(iris, "iris.xml") %in% dir())})
+
+test_that("Export to XML with ampersands",{
+    iris$`R & D` <- paste(sample(letters,nrow(iris),rep=T),
+                          '&',
+                          sample(LETTERS,nrow(iris),rep=TRUE))
+    expect_true(export(iris, "iris2.xml") %in% dir())
 })
 
 test_that("Import from XML", {
     expect_true(is.data.frame(import("iris.xml")))
 })
 
-unlink("iris.xml")
+unlink(c("iris.xml","iris2.xml"))


### PR DESCRIPTION
Except column headers for XML where '&' and ' ' both get replaced by '.'. Fixes #234

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation *not applicable*
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

TravisCI builds for this project still are failing (#246 and #242) and so this one will fail too. The simplest and fastest way to address that is to simply remove `xcode8.3`  from `.travis.yml`, so a more current default xcode version will be used for osx tests. Also, the manual install of `llvm` on osx is no longer required, the problem is fixed at the CRAN level (until the next R version bump?). Now it just contributes to CI failures by taking too long. In other words, the changes proposed in #247 (without the minor tweaks).

**After I submit this PR, I will submit an additional commit on this branch that makes the above two changes so you could see that the tests do pass. I apologize for deviating from normal "one issue per PR" process.**