### PR TITLE
Don't require arrow even if tests will not be run

### DIFF
--- a/tests/testthat/test_format_parquet.R
+++ b/tests/testthat/test_format_parquet.R
@@ -1,17 +1,10 @@
 context("Parquet imports/exports")
 require("datasets")
 
-if (arrow::arrow_available()) {
-    
-    test_that("Export to parquet", {
-        skip_if_not_installed("arrow")
-        expect_true(export(iris, "iris.parquet") %in% dir())
-    })
-
-    test_that("Import from parquet", {
-        skip_if_not_installed("arrow")
-        expect_true(is.data.frame(import("iris.parquet")))
-    })
-
+test_that("Export to and import from parquet", {
+    skip_if_not_installed("arrow")
+    skip_if_not(arrow::arrow_available())
+    expect_true(export(iris, "iris.parquet") %in% dir())
+    expect_true(is.data.frame(import("iris.parquet")))
     unlink("iris.parquet")
-}
+})


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

The parquet tests failed because the required `arrow` to be installed outside of the test if arrow is installed.  The test for arrow being available is now inside the test that it is installed.  (I don't use `arrow` yet, so I don't know if `skip_if_not(arrow::arrow_available())` is redundant with the previous line.