### PR TITLE
Support multiple tbody elements within an html table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rio development
 
-* HTML import can now handle multiple tbody elements within a single table. (#260 Bill Denney)
+* HTML import can now handle multiple tbody elements within a single table, a th element in a non-header row, and empty elements in either the header or data. (#260, #263, #264 Bill Denney)
 
 # rio 0.5.23
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rio development
+
+* HTML import can now handle multiple tbody elements within a single table. (#260 Bill Denney)
+
 # rio 0.5.23
 
 * CSVY support is now provided by `data.table::fread()` and `data.table::fwrite()`, providing significant performance gains.
@@ -19,7 +23,7 @@
 
 * Additional pointers were added to indicate how to load .doc, .docx, and .pdf files (#210, h/t Bill Denney)
 * Ensure that tests only run if the corresponding package is installed.  (h/t Bill Denney)
-* Escape ampersands for html and xml export (#234 Alex Bokov) 
+* Escape ampersands for html and xml export (#234 Alex Bokov)
 
 # rio 0.5.19
 
@@ -151,7 +155,7 @@
 
 # rio 0.4.24
 
-* Verbosity of `export(format = "fwf")` now depends on `options("verbose")`. 
+* Verbosity of `export(format = "fwf")` now depends on `options("verbose")`.
 * Fixed various errors, warnings, and messages in fixed-width format tests.
 * Modified defaults and argument handling in internal function `read_delim()`.
 * Fixed handling of "data.table", "tibble", and "data.frame" classes in `set_class()`. (#144)

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -444,7 +444,8 @@ function(file,
     }
     x <- xml2::as_list(tables[[which]])
     if ("tbody" %in% names(x)) {
-        x <- x[["tbody"]]
+        # Note that "tbody" may be specified multiple times in a valid html table
+        x <- unlist(x[names(x) %in% "tbody"], recursive=FALSE)
     }
     # loop row-wise over the table and then rbind()
     ## check for table header to use as column names

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -434,9 +434,27 @@ function(file,
     d
 }
 
+# This is a helper function for .import.rio_html
+extract_html_row <- function(x, empty_value) {
+  # Both <th> and <td> are valid for table data, and <th> may be used when
+  # there is an accented element (e.g. the first row of the table)
+  to_extract <- x[names(x) %in% c("th", "td")]
+  # Insert a value into cells that eventually will become empty cells (or they
+  # will be dropped and the table will not be generated).  Note that this more
+  # complex code for finding the length is required because of html like
+  # <td><br/></td>
+  unlist_length <-
+    sapply(
+      lapply(to_extract, unlist),
+      length
+    )
+  to_extract[unlist_length == 0] <- list(empty_value)
+  unlist(to_extract)
+}
+
 #' @importFrom utils type.convert
 #' @export
-.import.rio_html <- function(file, which = 1, stringsAsFactors = FALSE, ...) {
+.import.rio_html <- function(file, which = 1, stringsAsFactors = FALSE, ..., empty_value = "") {
     # find all tables
     tables <- xml2::xml_find_all(xml2::read_html(unclass(file)), ".//table")
     if (which > length(tables)) {
@@ -449,18 +467,19 @@ function(file,
     }
     # loop row-wise over the table and then rbind()
     ## check for table header to use as column names
+    col_names <- NULL
     if ("th" %in% names(x[[1]])) {
-        col_names <- unlist(x[[1]][names(x[[1]]) %in% "th"])
-        out <- do.call("rbind", lapply(x[-1], function(y) {
-            unlist(y[names(y) %in% "td"])
-        }))
-        colnames(out) <- col_names
-    } else {
-        out <- do.call("rbind", lapply(x, function(y) {
-            unlist(y[names(y) %in% "td"])
-        }))
-        colnames(out) <- paste0("V", seq_len(ncol(out)))
+      col_names <- extract_html_row(x[[1]], empty_value=empty_value)
+      # Drop the first row since column names have already been extracted from it.
+      x <- x[-1]
     }
+    out <- do.call("rbind", lapply(x, extract_html_row, empty_value=empty_value))
+    colnames(out) <-
+      if (is.null(col_names)) {
+        paste0("V", seq_len(ncol(out)))
+      } else {
+        col_names
+      }
     out <- as.data.frame(out, ..., stringsAsFactors = stringsAsFactors)
     # set row names
     rownames(out) <- 1:nrow(out)

--- a/tests/testthat/files/br-in-header.html
+++ b/tests/testthat/files/br-in-header.html
@@ -1,0 +1,6 @@
+<html><body>
+<table><tbody>
+<tr><th><br></th><th>Date</th></tr>
+<tr><td>1</td><td>December 15, 2003 13:14:17.123</td></tr>
+</tbody></table>
+</html></body>

--- a/tests/testthat/files/br-in-td.html
+++ b/tests/testthat/files/br-in-td.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<table><tbody>
+<tr><th>Row</th><th>STUDYID</th></tr>
+<tr><th>1</th><td><br/></td></tr>
+<tr><th>2</th><td><br/></td></tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/testthat/files/th-as-row-element.html
+++ b/tests/testthat/files/th-as-row-element.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<table><tbody>
+<tr><th>Row</th><th>STUDYID</th></tr>
+<tr><th>1</th><td>ABC</td></tr>
+<tr><th>2</th><td>ABC</td></tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/testthat/files/two-tbody.html
+++ b/tests/testthat/files/two-tbody.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<table>
+<tbody>
+<tr><th>Dataset</th><th>Description</th></tr>
+</tbody>
+<tbody>
+<tr><td>CO</td><td>Comments</td></tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/tests/testthat/test_format_html.R
+++ b/tests/testthat/test_format_html.R
@@ -26,6 +26,9 @@ test_that("Import from HTML", {
 test_that("Import from HTML with multiple tbody elements", {
     skip_if_not_installed("xml2")
     expect_true(is.data.frame(import("files/two-tbody.html")), label="import with two tbody elements in a single html table works")
+    expect_true(is.data.frame(import("files/br-in-header.html")), label="import with an empty header cell in an html table works")
+    expect_true(is.data.frame(import("files/br-in-td.html")), label="import with an empty data cell in a single html table works")
+    expect_true(is.data.frame(import("files/th-as-row-element.html")), label="import with th instead of td in a non-header row in a single html table works")
 })
 
 unlink(c("iris.xml","iris2.xml"))

--- a/tests/testthat/test_format_html.R
+++ b/tests/testthat/test_format_html.R
@@ -15,13 +15,17 @@ test_that("Export to HTML with ampersands",{
               label = "export to html with ampersands works")
 })
 
-
 test_that("Import from HTML", {
     skip_if_not_installed("xml2")
     expect_true(is.data.frame(import("iris.html")), label = "import from single-table html works")
     f <- system.file("examples", "twotables.html", package = "rio")
     expect_true(all(dim(import(f, which = 1)) == c(32, 11)), label = "import from two-table html works (which = 1)")
     expect_true(all(dim(import(f, which = 2)) == c(150, 5)), label = "import from two-table html works (which = 2)")
+})
+
+test_that("Import from HTML with multiple tbody elements", {
+    skip_if_not_installed("xml2")
+    expect_true(is.data.frame(import("files/two-tbody.html")), label="import with two tbody elements in a single html table works")
 })
 
 unlink(c("iris.xml","iris2.xml"))


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

Ref #260 

Support multiple tbody elements within an html table.

(R CMD check doesn't work because it's waiting on the previous PR, and I don't want to merge the two PRs as I typically find that to be bad form.)