### PR TITLE
Don't evaluate ellipsis in import()

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -126,7 +126,6 @@ import <- function(file, format, setclass, which, ...) {
         fmt <- get_type(format)
     }
     
-    args_list <- list(...)
     
     class(file) <- c(paste0("rio_", fmt), class(file))
     if (missing(which)) {
@@ -141,13 +140,13 @@ import <- function(file, format, setclass, which, ...) {
     }
     # otherwise, make sure it's a data frame (or requested class)
     if (missing(setclass) || is.null(setclass)) {
-        if ("data.table" %in% names(args_list) && isTRUE(args_list[["data.table"]])) {
+        if (hasArg(data.table) && isTRUE(eval(match.call()$data.table))) {
             return(set_class(x, class = "data.table"))
         } else {
             return(set_class(x, class = "data.frame"))
         }
     } else {
-        if ("data.table" %in% names(args_list) && isTRUE(args_list[["data.table"]])) {
+        if (hasArg(data.table) && isTRUE(eval(match.call()$data.table))) {
             if (setclass != "data.table") {
                 warning(sprintf("'data.table = TRUE' argument overruled. Using setclass = '%s'", setclass))
                 return(set_class(x, class = setclass))

--- a/tests/testthat/test_format_sas.R
+++ b/tests/testthat/test_format_sas.R
@@ -14,5 +14,9 @@ test_that("Export SAS (.sas7bdat)", {
     expect_true(export(mtcars, "mtcars.sas7bdat") %in% dir())
 })
 
+test_that("can use select helpers to pick columns (#248)", {
+    expect_named(import("mtcars.sas7bdat", col_select = any_of("mpg")), "mpg")
+})
+
 unlink("mtcars.sas7bdat")
 unlink("mtcars.xpt")

--- a/tests/testthat/test_format_sas.R
+++ b/tests/testthat/test_format_sas.R
@@ -15,6 +15,9 @@ test_that("Export SAS (.sas7bdat)", {
 })
 
 test_that("can use select helpers to pick columns (#248)", {
+    if (packageVersion("haven") < "2.2.0") {
+        skip("col_select was added in haven 2.2.0")
+    }
     expect_named(import("mtcars.sas7bdat", col_select = any_of("mpg")), "mpg")
 })
 


### PR DESCRIPTION
These changes avoid evaluating `...` in `import()`, enabling the back-end functions to have control over evaluation.

Contributes to #248 by enabling the use of tidyselect select helpers in `col_select` for haven-based formats.