### PR TITLE
Correct the test case in test_format_fwf , ref  #289

### DIFF
--- a/tests/testthat/test_format_fwf.R
+++ b/tests/testthat/test_format_fwf.R
@@ -8,7 +8,7 @@ test_that("Export to FWF", {
 
 test_that("Import from FWF (read.fwf)", {
     expect_true(is.data.frame(import("iris.fwf", widths = c(3,3,3,3,1))))
-    expect_true(is.data.frame(import("iris.fwf", widths = list(3,3,3,3,1))))
+    expect_true(is.data.frame(import("iris.fwf", widths = list(c(3,3,3,3,1)))))
     expect_true(is.data.frame(import("iris.fwf", widths = c(3,3,3,3,1), col.names = names(iris))))
     expect_true(is.data.frame(import("iris.fwf", widths = c(3,3,3,3,1), col.names = names(iris), readr = TRUE)))
     expect_true(is.data.frame(import("iris.txt", widths = c(3,3,3,3,1), format = "fwf")))


### PR DESCRIPTION
The test case with `widths=list(3,3,3,3,1)` is not correct because the
original `read.fwf` asks for " list of integer vectors giving widths
for multiline records", not a list of integer numbers.

Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/rio/issues/new) first
 - [X for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/rio/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/rio/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/leeper/rio/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

